### PR TITLE
created new template for GWC blob store - user w/ policies and bucket

### DIFF
--- a/cloudformation/geowebcache_user_with_bucket.yml
+++ b/cloudformation/geowebcache_user_with_bucket.yml
@@ -1,0 +1,51 @@
+
+# Stack template for generating a bucket and user with necessary access to that bucket
+#   for the purposes of geowebcache blob storage
+
+
+Parameters:
+ 
+  UserName:
+    Type: String
+    Description: name for geowebcache user
+  
+  BucketName:
+    Type: String
+    Description: name for S3 bucket for geowebcache blob storage
+
+Resources:
+ 
+  Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties: 
+      BucketName: !Sub ${BucketName}
+
+  User:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: !Sub ${UserName}
+      Policies:
+      - PolicyName: !Sub ${BucketName}-s3-bucket-access
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - s3:ListAllMyBuckets
+              Resource:
+                - arn:aws:s3:::*
+            - Effect: Allow
+              Action:
+                - s3:DeleteObject
+                - s3:Get*
+                - s3:PutObject
+                - s3:PutObjectAcl
+              Resource: 
+                - !Sub "arn:aws:s3:::${BucketName}/*"
+            - Effect: Allow
+              Action:
+                - s3:ListBucket
+                - s3:GetBucketAcl
+              Resource:
+                - !Sub arn:aws:s3:::${BucketName}
+         


### PR DESCRIPTION
I just created this because I needed to run up an RC geowebcache in the AWS dev environment and needed a bucket plus user (with access policies to the bucket). Discussed with Leigh and decided to provision with Cloudformation and hence this template.