### PR TITLE
 Exclude beanstalk environments with AutoOff tag set to False

### DIFF
--- a/cloudformation/lambda/auto_off_beanstalk/auto_off_beanstalk.py
+++ b/cloudformation/lambda/auto_off_beanstalk/auto_off_beanstalk.py
@@ -7,8 +7,6 @@ logger.setLevel(logging.INFO)
 
 # define the connection
 client = boto3.client('elasticbeanstalk')
-skip_envs = ["geoserver-systest", "geowebcache-systest", 'aodn-portal-sandbox', 'geoserver-sandbox',
-             'geowebcache-sandbox', 'thredds-sandbox']
 
 
 def handler(event, context):
@@ -33,9 +31,6 @@ def is_excluded(env):
             return True
 
     if env['EnvironmentName'].endswith('-prod'):
-        return True
-
-    if env['EnvironmentName'] in skip_envs:
         return True
 
     if env['Status'] not in ('Updating', 'Ready'):


### PR DESCRIPTION
This will allow us to set which environments shouldn't be pulled down each night at the level of the environment rather than having them hardcoded into this script.