### PR TITLE
adds hosts to csv record

### DIFF
--- a/pipeline/talend_test/ansible/playbook.yaml
+++ b/pipeline/talend_test/ansible/playbook.yaml
@@ -16,7 +16,7 @@
 
     - name: create time_profile.csv if not already exists
       copy:
-        content: "test,action_type,elapsed_seconds"
+        content: "test,host,action_type,elapsed_seconds"
         dest: ../time_profile.csv
         force: no
       delegate_to: localhost

--- a/pipeline/talend_test/ansible/process_action.yaml
+++ b/pipeline/talend_test/ansible/process_action.yaml
@@ -118,6 +118,6 @@
   lineinfile:
     create: true
     path: ../time_profile.csv
-    line: "{{ name }},{{ action_item.type }}, {{ elapsed_time }}"
+    line: "{{ name }},{{ hosts }},{{ action_item.type }},{{ elapsed_time }}"
     insertafter: EOF
   delegate_to: localhost


### PR DESCRIPTION
@jonescc just a small fix. I realised that the time profiling needs to include the _host_ that the test was run on otherwise you don't know what to compare.