### PR TITLE
removes user-editable variables from global_vars

### DIFF
--- a/pipeline/talend_test/README.md
+++ b/pipeline/talend_test/README.md
@@ -62,6 +62,17 @@ diff -r harvest_results/6-nec-hob.emii.org.au harvest_results/9-nec-hob.emii.org
 
 ##Options
 
+### Database user parameter
+In case your harvest database user differs from your remote ssh user, add `db_user=<your_harvest_username>` to the list of `--extra-vars` e.g.
+
+```
+ansible-playbook ansible/playbook.yaml \
+  -e @test_configs/anfog_dm.yaml \
+  --ask-pass --user <your_ssh_user> \
+  --extra-vars "hosts=6-nec-hob.emii.org.au db_user=<your_harvest_username>" \
+  --tags "init_db_only"
+```
+
 ### Run only the db initialisation step for schemas in the test
 
 

--- a/pipeline/talend_test/ansible/harvest_results.yaml
+++ b/pipeline/talend_test/ansible/harvest_results.yaml
@@ -23,11 +23,15 @@
   with_items: "{{ database_schemas }}"
 
 
+- set_fact:
+    database_user: "{{ db_user | default(ansible_ssh_user) }}"
+
+
 - name: sql select queries
   psql_harvest_queries:
     schema_obj: "{{ item }}"
     tmp_dir: "{{ tmp_dir }}/{{ item.name }}"
-    db_user: "{{ db_user }}"
+    db_user: "{{ database_user }}"
     db_host: "{{ hosts }}"
   loop: "{{ database_schemas }}"
 

--- a/pipeline/talend_test/ansible/process_action.yaml
+++ b/pipeline/talend_test/ansible/process_action.yaml
@@ -43,7 +43,7 @@
   become: yes
   become_user: root
   copy:
-    src: "{{ input_files_dir }}/{{ name }}/{{ item.local_file }}"
+    src: "../input_files/{{ name }}/{{ item.local_file }}"
     dest: "{{ item.dest }}/{{ item.remote_file if item.remote_file is defined else item.local_file }}"
     owner: projectofficer
     group: projectofficer

--- a/pipeline/talend_test/global_vars.yaml
+++ b/pipeline/talend_test/global_vars.yaml
@@ -1,6 +1,2 @@
 
-input_files_dir: /<your_local_path_to>/utilities/pipeline/talend_test/input_files
 pipeline_1_process_log: /mnt/ebs/log/data-services/process.log
-
-# database access
-db_user: <your_harvest_db_user_name>


### PR DESCRIPTION
@jonescc or @craigrose 

Just getting round to making an adjustment so that we don't have to make our own updates to the global_vars file. 

- the location for `input_files` is not just assumed by the project structure. Now that the project has stabilised I think we can always assume now where this folder is going to be.
- the `db_user` variable is now going to be assumed to be the same as your remote user that you supply as `--user` when running the playbook. I'm pretty sure this _should_ be the case for everyone but let me know if it's different for you
