### PR TITLE
talend log directory check before proceeding

### DIFF
--- a/pipeline/talend_test/ansible/playbook.yaml
+++ b/pipeline/talend_test/ansible/playbook.yaml
@@ -12,6 +12,18 @@
 
   tasks:
 
+    # checks
+
+    - set_fact:
+        test_dir: "{{ talend_log_dir | default(talend_log_file) }}"
+
+
+    - name: test log dir in allowed dirs
+      allowed_dir:
+        allowed_dirs: "{{ allowed_log_dirs }}"
+        test: "{{ test_dir }}"
+
+
     # setup: time profiling csv file
 
     - name: create time_profile.csv if not already exists

--- a/pipeline/talend_test/ansible/roles/talend_test/library/allowed_dir.py
+++ b/pipeline/talend_test/ansible/roles/talend_test/library/allowed_dir.py
@@ -1,0 +1,47 @@
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def prep_dir(dir_or_file):
+    if '.' in os.path.basename(dir_or_file):
+        return os.path.dirname(dir_or_file)
+    else:
+        return os.path.dirname(dir_or_file)
+
+
+def run_module():
+
+    module_args = dict(
+        allowed_dirs=dict(type='list', required=True),
+        test=dict(type='str', required=True)
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    p = type('Params', (), module.params)
+
+    test = prep_dir(p.test)
+
+    found = []
+
+    for allowed_dir in p.allowed_dirs:
+        if test == allowed_dir.rstrip('/'):
+            found.append(allowed_dir)
+
+    if len(found) > 0:
+        module.exit_json(changed=False)
+
+    module.fail_json(msg="directory not in allowed directories")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline/talend_test/ansible/roles/talend_test/library/allowed_dir.py
+++ b/pipeline/talend_test/ansible/roles/talend_test/library/allowed_dir.py
@@ -8,7 +8,7 @@ def prep_dir(dir_or_file):
     if '.' in os.path.basename(dir_or_file):
         return os.path.dirname(dir_or_file)
     else:
-        return os.path.dirname(dir_or_file)
+        return os.path.dirname(dir_or_file.rstrip('/'))
 
 
 def run_module():

--- a/pipeline/talend_test/ansible/roles/talend_test/library/allowed_dir_test.json
+++ b/pipeline/talend_test/ansible/roles/talend_test/library/allowed_dir_test.json
@@ -1,0 +1,6 @@
+{
+  "ANSIBLE_MODULE_ARGS": {
+      "allowed_dirs": ["/test"],
+      "test": "/test/some.file"
+    }
+}

--- a/pipeline/talend_test/global_vars.yaml
+++ b/pipeline/talend_test/global_vars.yaml
@@ -1,9 +1,6 @@
 
 pipeline_1_process_log: /mnt/ebs/log/data-services/process.log
 
-# database access
-db_user: <your_harvest_db_user_name>
-
 allowed_log_dirs:
   - /mnt/ebs/log/data-services
   - /mnt/ebs/log/pipeline/process

--- a/pipeline/talend_test/global_vars.yaml
+++ b/pipeline/talend_test/global_vars.yaml
@@ -4,3 +4,9 @@ pipeline_1_process_log: /mnt/ebs/log/data-services/process.log
 
 # database access
 db_user: <your_harvest_db_user_name>
+
+allowed_log_dirs:
+  - /mnt/ebs/log/data-services
+  - /mnt/ebs/log/pipeline/process
+  - /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt
+


### PR DESCRIPTION
@craigrose or @jonescc 

Bug fix: there's now a check added so that any talend log files or directories that need to be deleted are contained in a list of whitelisted directories. 

I've added whitelisted dirs to global_vars.yaml already which will cover pretty much all pipeline 1 and 2. Any other cases e.g. running harvesters directly might require a new entry