### PR TITLE
separates the drop schema objects action from the run talend liqui action

### DIFF
--- a/pipeline/talend_test/ansible/playbook.yaml
+++ b/pipeline/talend_test/ansible/playbook.yaml
@@ -42,7 +42,7 @@
       command: psql -d harvest -c "select drop_objects_in_schema('"{{ item.name }}"');"
       register: truncate_schema
       with_items: "{{ database_schemas }}"
-      when: create_schema == true
+      when: (drop_schema_objects is defined) and drop_schema_objects == true
       tags:
         - init_db_only
 
@@ -54,7 +54,7 @@
         talend_regex="___"{{ item }}"___";
         /usr/local/talend/bin/talend-trigger -c /usr/local/talend/etc/trigger.conf --delete -f $talend_regex,$talend_regex
       with_items: "{{ talend_jobs }}"
-      when: create_schema == true
+      when: (run_talend_liqui is defined) and run_talend_liqui == true
       tags:
         - init_db_only
 

--- a/pipeline/talend_test/test_configs/aatams_sattag_dm.yaml
+++ b/pipeline/talend_test/test_configs/aatams_sattag_dm.yaml
@@ -12,7 +12,8 @@ actions:
     files:
       - dest: /mnt/ebs/incoming/AATAMS/AATAMS_SATTAG_DM
         local_file: ct100.zip
-create_schema: false
+drop_schema_objects: false
+run_talend_liqui: false
 talend_log_dir: /mnt/ebs/log/data-services/AATAMS_SATTAG_DM
 talend_jobs:
   - aatams_sattag_dm-aatams_sattag_dm

--- a/pipeline/talend_test/test_configs/aatams_sattag_nrt.yaml
+++ b/pipeline/talend_test/test_configs/aatams_sattag_nrt.yaml
@@ -16,8 +16,8 @@ actions:
         local_file: IMOS_AATAMS-SATTAG_TSP_20190416T214000Z_Q9901199_FV00.nc
       - dest: /mnt/ebs/wip/AATAMS/AATAMS_sattag_nrt/NETCDF/AATAMS/AATAMS_sattag_nrt/Q9901199/profiles
         local_file: IMOS_AATAMS-SATTAG_TSP_20190417T022000Z_Q9901199_FV00.nc
-
-create_schema: true
+drop_schema_objects: true
+run_talend_liqui: true
 talend_log_dir: /mnt/ebs/log/data-services/AATAMS_SATTAG_NRT
 talend_jobs:
   - aatams_sattag_nrt-aatams_sattag_nrt
@@ -29,4 +29,3 @@ database_schemas:
         exclude_columns: [colour]
       - name: aatams_sattag_nrt_profile_data
         exclude_columns: [colour]
-

--- a/pipeline/talend_test/test_configs/abos_asfs.yaml
+++ b/pipeline/talend_test/test_configs/abos_asfs.yaml
@@ -16,7 +16,8 @@ actions:
   - type: DELETE
     file: IMOS/ABOS/ASFS/SOFS/Surface_properties/Real-time/2019_daily/IMOS_ABOS-ASFS_CMST_20190323T005900Z_SOFS_FV01_C-20190324T002503Z.nc
 
-create_schema: true
+drop_schema_objects: true
+run_talend_liqui: true
 talend_log_dir: /mnt/ebs/log/data-services/ABOS_ASFS
 talend_jobs:
   - abos_sofs_sp-abos_sofs_sp

--- a/pipeline/talend_test/test_configs/anfog_dm.yaml
+++ b/pipeline/talend_test/test_configs/anfog_dm.yaml
@@ -8,7 +8,8 @@ actions:
     files:
     - dest: /mnt/ebs/incoming/ANFOG/processed
       local_file: TasEastCoast20190213.zip
-create_schema: true
+drop_schema_objects: true
+run_talend_liqui: true
 talend_log_file: /mnt/ebs/log/pipeline/process/tasks.ANFOG_DM.log
 talend_jobs:
   - anfog_dm-anfog_dm

--- a/pipeline/talend_test/test_configs/anmn_wa.yaml
+++ b/pipeline/talend_test/test_configs/anmn_wa.yaml
@@ -15,7 +15,8 @@ actions:
       remote_file: IMOS_ANMN-NRS_TZ_20081120T080000Z_NRSROT_FV01_NRSROT-0811-SBE39-27_END-20090219T030000Z_C-20180810T044335Z.nc
   - type: DELETE
     file: IMOS/ANMN/NRS/NRSROT/Temperature/IMOS_ANMN-NRS_TZ_20081120T080000Z_NRSROT_FV01_NRSROT-0811-SBE39-27_END-20090219T030000Z_C-20180810T044335Z.nc
-create_schema: true
+drop_schema_objects: true
+run_talend_liqui: true
 talend_log_file: /mnt/ebs/log/pipeline/process/tasks.ANMN_WA.log
 talend_jobs:
   - anmn_ts_timeseries-anmn_ts_timeseries

--- a/pipeline/talend_test/test_configs/aodn_nsw_oeh.yaml
+++ b/pipeline/talend_test/test_configs/aodn_nsw_oeh.yaml
@@ -54,7 +54,8 @@ actions:
   - type: DELETE
     file: NSW-OEH/Multi-beam/2015/20150302_HawkesNestPortStephens/NSWOEH_20150302_HawkesNestPortStephens_MB_ScientificRigour.pdf
 
-create_schema: true
+drop_schema_objects: true
+run_talend_liqui: true
 talend_log_dir: /mnt/ebs/log/data-services/AODN_NSW_OEH
 talend_jobs:
   - aodn_nsw_oeh-aodn_nsw_oeh

--- a/pipeline/talend_test/test_configs/aodn_wave_nrt.yaml
+++ b/pipeline/talend_test/test_configs/aodn_wave_nrt.yaml
@@ -8,7 +8,8 @@ actions:
     files:
       - dest: /mnt/ebs/wip/AODN_WAVE_NRT
         local_file: Buoys_metadata.csv
-create_schema: false
+drop_schema_objects: false
+run_talend_liqui: false
 exec_shell_script: /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt/bin/aodn_wave_nrt-aodn_wave_nrt.sh
 talend_log_dir: /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt/log
 talend_jobs:

--- a/pipeline/talend_test/test_configs/argo.yaml
+++ b/pipeline/talend_test/test_configs/argo.yaml
@@ -24,7 +24,8 @@ actions:
        local_file: R2901616_001.nc
      - dest: /mnt/ebs/incoming/Argo
        local_file: argo_rsync.20190416-112046.rsync_manifest
-create_schema: true
+drop_schema_objects: true
+run_talend_liqui: true
 talend_log_file: /mnt/ebs/log/pipeline/process/tasks.ARGO.log
 talend_jobs:
   - argo-argo

--- a/pipeline/talend_test/test_configs/soop_trv.yaml
+++ b/pipeline/talend_test/test_configs/soop_trv.yaml
@@ -8,7 +8,8 @@ actions:
     files:
     - dest: /mnt/ebs/incoming/SOOP/TRV
       local_file: IMOS_SOOP-TRV_S_20190328T191556Z_VMQ9273_FV01_END-20190407T215725Z.nc
-create_schema: true
+drop_schema_objects: true
+run_talend_liqui: true
 talend_log_file: /mnt/ebs/log/pipeline/process/tasks.SOOP_TRV.log
 talend_jobs:
   - soop_trv-soop_trv


### PR DESCRIPTION
@jonescc 

`create_schema` is now two separate variable:
```
drop_schema_objects: 
run_talend_liqui:
```
I've applied this change to all the test configs that are already in master.
