### PR TITLE
change to using log file instead of log dir when waiting for completion

### DIFF
--- a/pipeline/talend_test/test_configs/aodn_wave_nrt.yaml
+++ b/pipeline/talend_test/test_configs/aodn_wave_nrt.yaml
@@ -10,7 +10,7 @@ actions:
         local_file: Buoys_metadata.csv
 create_schema: false
 exec_shell_script: /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt/bin/aodn_wave_nrt-aodn_wave_nrt.sh
-talend_log_dir: /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt/log
+talend_log_file: /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt/log/console.log
 talend_jobs:
   - aodn_wave_nrt-aodn_wave_nrt
 database_schemas:


### PR DESCRIPTION
@jonescc I've just updated one of the other 'harvester' type test configs following our change to using the talend file directly (instead of the directory) when waiting for 'finish;'