### PR TITLE
allow optional schema restore from backup

### DIFF
--- a/pipeline/talend_test/README.md
+++ b/pipeline/talend_test/README.md
@@ -18,6 +18,10 @@ Create .pgpass entries
 - e.g. add an entry like this:
   ```6-nec-hob.emii.org.au:5432:harvest:<your_db_username>:<your_db_password>```
 
+If performing a schema restore (from backup) as part of the test you will need aws access
+```
+export AWS_PROFILE=production-developer
+```
 
 ## run tests
 

--- a/pipeline/talend_test/ansible/playbook.yaml
+++ b/pipeline/talend_test/ansible/playbook.yaml
@@ -73,6 +73,10 @@
         - init_db_only
 
 
+    - include: schema_restore.yaml
+      when: schema_restore is defined
+
+
     - include: process_action.yaml
       loop: "{{ actions }}"
       loop_control:

--- a/pipeline/talend_test/ansible/schema_restore.yaml
+++ b/pipeline/talend_test/ansible/schema_restore.yaml
@@ -1,0 +1,32 @@
+- name: create schema download directory
+  delegate_to: localhost
+  file:
+    path: /tmp/talend_test_schemas
+    state: directory
+
+
+- name: download schema backup to local
+  delegate_to: localhost
+  aws_s3:
+    bucket: imos-backups
+    object: "{{ schema_restore.object.path }}/{{ item.name }}.dump"
+    dest: "/tmp/talend_test_schemas/{{ item.name }}.dump"
+    mode: get
+  loop: "{{ database_schemas }}"
+
+
+- name: upload schema backup to remote
+  copy:
+    src: "/tmp/talend_test_schemas/{{ item.name }}.dump"
+    dest: /tmp/
+  loop: "{{ database_schemas }}"
+
+
+- name: drop schema
+  command: "sudo -u postgres psql -d harvest -c 'DROP SCHEMA {{ item.name }} CASCADE;'"
+  loop: "{{ database_schemas }}"
+
+
+- name: run pg_restore on schema backup
+  command: "sudo -u postgres pg_restore -d harvest /tmp/{{ item.name }}.dump"
+  loop: "{{ database_schemas }}"

--- a/pipeline/talend_test/requirements.txt
+++ b/pipeline/talend_test/requirements.txt
@@ -1,1 +1,2 @@
 ansible
+boto3


### PR DESCRIPTION
@jonescc 

I've just added a feature to easily restore schemas from backups. 
You can test by adding this to `aodn_nsw_oeh.yaml

```

schema_restore:
  object:
    path: backups/2-aws-syd.emii.org.au/pgsql/2019.05.15.05.05.41/harvest
```