### PR TITLE
allows entire directories to be specified for delete actions

### DIFF
--- a/pipeline/talend_test/README.md
+++ b/pipeline/talend_test/README.md
@@ -109,6 +109,13 @@ actions:
 ...
 ```
 
+## Deleting files
+
+The DELETE action can take either a `file` or a `path` as a parameter.
+ 
+- `file` specifies a single file to delete. 
+- `path` specifies a directory in which _all files will be deleted_
+
 ## Notes
 
 - Running a test first removes pipeline/harvest logs. This is needed so that the playbook can perform a `wait` action and detect when processing has completed.

--- a/pipeline/talend_test/ansible/playbook.yaml
+++ b/pipeline/talend_test/ansible/playbook.yaml
@@ -26,7 +26,10 @@
       when: test_dir is defined
 
 
-    # setup: time profiling csv file
+    # setup
+
+    - set_fact:
+        host_bucket: "{{ host_buckets[hosts] }}"
 
     - name: create time_profile.csv if not already exists
       copy:

--- a/pipeline/talend_test/ansible/process_action.yaml
+++ b/pipeline/talend_test/ansible/process_action.yaml
@@ -52,15 +52,33 @@
   when: action_item.type == 'ADD' or action_item.type == 'UPDATE'
 
 
+- name: list s3 objects to delete
+  shell: "aws s3 ls --recursive s3://{{ host_bucket }}/{{ action_item.path }} | awk '{print $4}'"
+  register: objects_list
+  when: (type == 'pipeline_version_1' or type == 'pipeline_version_2') and
+        action_item.type == 'DELETE' and action_item.path is defined
+  delegate_to: localhost
+
+
+- set_fact:
+    delete_list: "{{ [ action_item.file ] }}"
+  when: (type == 'pipeline_version_1' or type == 'pipeline_version_2') and
+        action_item.type == 'DELETE' and action_item.file is defined
+
+
+- set_fact:
+    delete_list: "{{ objects_list.stdout_lines|list }}"
+  when: objects_list is defined
+
+
   # note: the po_s3_del command succeeds even when it tries to delete a key that doesn't exist
   # (fails if given a 'folder' i.e. object ending with '/'
 - name: delete files using po_s3_del
   become: yes
   become_user: root
-  command: "sudo -u projectofficer -i po_s3_del {{ action_item.file }}"
-  register: po_s3_del
-  when: (type == 'pipeline_version_1' or type == 'pipeline_version_2') and
-        action_item.type == 'DELETE'
+  command: "sudo -u projectofficer -i po_s3_del {{ item }}"
+  with_items: "{{ delete_list }}"
+  when: delete_list is defined
 
 
 - name: execute script

--- a/pipeline/talend_test/global_vars.yaml
+++ b/pipeline/talend_test/global_vars.yaml
@@ -6,3 +6,7 @@ allowed_log_dirs:
   - /mnt/ebs/log/pipeline/process
   - /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt/log
   - /usr/local/talend/jobs/soop_auscpr-soop_auscpr/log
+
+host_buckets:
+  6-nec-hob.emii.org.au: imos-data-pipeline-2
+  9-nec-hob.emii.org.au: imos-data-pipeline-talend7


### PR DESCRIPTION
@jonescc I decided to implement a better method for s3 object deletion rather than have to specify every single object that needs to be deleted.

With this PR, you can _optionally_ specify a `path` and ansible will enumerate all the objects in that directory and issue the `po_s3_del` command on them individually.

To test, you can edit `aodn_nsw_oeh.yaml` like so:
```
  - type: DELETE 
    path: NSW-OEH/Multi-beam/2015/20150302_HawkesNestPortStephens 
```

