### PR TITLE
Add test config for aodn_imas_fluorometry

### DIFF
--- a/pipeline/talend_test/global_vars.yaml
+++ b/pipeline/talend_test/global_vars.yaml
@@ -7,6 +7,7 @@ allowed_log_dirs:
   - /usr/local/talend/jobs/aodn_wave_nrt-aodn_wave_nrt/log
   - /usr/local/talend/jobs/soop_auscpr-soop_auscpr/log
   - /usr/local/talend/jobs/aodn_wamsi_sediment-aodn_wamsi_sediment/log
+  - /usr/local/talend/jobs/aodn_imas_fluorometry-aodn_imas_fluorometry/log
 
 host_buckets:
   6-nec-hob.emii.org.au: imos-data-pipeline-2

--- a/pipeline/talend_test/test_configs/aodn_imas_fluorometry.yaml
+++ b/pipeline/talend_test/test_configs/aodn_imas_fluorometry.yaml
@@ -1,0 +1,27 @@
+
+
+name: aodn_imas_fluorometry
+type: harvester
+po: xavier
+actions:
+- type: NONE
+drop_schema_objects: true
+run_talend_liqui: false
+exec_shell_script:
+  script: /usr/local/talend/jobs/aodn_imas_fluorometry-aodn_imas_fluorometry/bin/aodn_imas_fluorometry-aodn_imas_fluorometry.sh
+  asynchronous: true
+talend_log_file: /usr/local/talend/jobs/aodn_imas_fluorometry-aodn_imas_fluorometry/log/console.log
+talend_jobs:
+- aodn_imas_fluorometry-aodn_imas_fluorometry
+schema_restore:
+  object:
+    path: backups/2-aws-syd.emii.org.au/pgsql/2019.05.21.05.14.20/harvest
+database_schemas:
+-
+  name: aodn_imas_fluorometry
+  tables:
+  - name: aodn_imas_fluorometry_map
+    exclude_columns: []
+  - name: aodn_imas_fluorometry_data
+    exclude_columns: []
+


### PR DESCRIPTION
Its not possible to run this on an empty schema at the moment (get org.postgresql.util.PSQLException: ERROR: column "i.url" must appear in the GROUP BY clause or be used in an aggregate function). So this is the best test we can do.  Running on an empty schema will need to be tested when the issue is fixed (https://github.com/aodn/harvesters/issues/732).