### PR TITLE
fix issue where /tmp diskspace used up on remote

### DIFF
--- a/pipeline/talend_test/ansible/schema_restore.yaml
+++ b/pipeline/talend_test/ansible/schema_restore.yaml
@@ -25,7 +25,7 @@
 
 
 - name: upload schema backup to remote
-  copy:
+  synchronize:
     src: "/tmp/talend_test_schemas/{{ item.name }}.dump"
     dest: /mnt/talend_test_schemas
   loop: "{{ database_schemas }}"
@@ -40,17 +40,21 @@
   command: "sudo -u postgres pg_restore -d harvest /mnt/talend_test_schemas/{{ item.name }}.dump"
   loop: "{{ database_schemas }}"
 
+
 - name: remove schema dump from remote disk
   file:
     state: absent
     path: "/mnt/talend_test_schemas/{{ item.name }}.dump"
   loop: "{{ database_schemas }}"
 
+
 - name: remove schema dump from local disk
+  delegate_to: localhost
   file:
     state: absent
     path: "/tmp/talend_test_schemas/{{ item.name }}.dump"
   loop: "{{ database_schemas }}"
+
 
 
 


### PR DESCRIPTION
basically the `syncronize` module usus rsync under the hood and therefore doesn't use any temporary dir