### PR TITLE
Fix style issues after DOD

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
@@ -87,20 +87,20 @@
                                 </xsl:otherwise>
                             </xsl:choose>
                         </cit:date>
-                        <xsl:choose>
-                            <xsl:when test=".//gmd:dateType/gmd:CI_DateTypeCode/@codeListValue != ''">
-                                <xsl:for-each select="descendant::gmd:dateType">
+                        <xsl:for-each select="descendant::gmd:dateType">
+                            <xsl:choose>
+                                <xsl:when test="gmd:CI_DateTypeCode/@codeListValue != ''">
                                     <xsl:call-template name="writeCodelistElement">
                                         <xsl:with-param name="elementName" select="'cit:dateType'"/>
                                         <xsl:with-param name="codeListName" select="'cit:CI_DateTypeCode'"/>
                                         <xsl:with-param name="codeListValue" select="gmd:CI_DateTypeCode/@codeListValue"/>
                                     </xsl:call-template>
-                                </xsl:for-each>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <cit:dateType />
-                            </xsl:otherwise>
-                        </xsl:choose>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <cit:dateType gco:nilReason="missing"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:for-each>
                     </cit:CI_Date>
                 </xsl:otherwise>
             </xsl:choose>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/DQ.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/DQ.xsl
@@ -122,10 +122,6 @@
             <xsl:when test="../../../gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode/@codeListValue != ''">
               <xsl:apply-templates select="../../../gmd:DQ_DataQuality" mode="dataQualityScope"/>
             </xsl:when>
-            <xsl:when test="../../../gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope/gmd:level/gmx:MX_ScopeCode/@codeListValue != ''">
-              <xsl:variable name="dataQualityScopeObject" select="../../../gmd:DQ_DataQuality/gmd:scope/gmd:DQ_Scope"/>
-              <xsl:apply-templates select="../../../gmd:DQ_DataQuality" mode="dataQualityScope"/>
-            </xsl:when>
             <xsl:otherwise>
               <mrl:scope />
             </xsl:otherwise>


### PR DESCRIPTION
Remove unused when clause and include codeListValue check in for loop for CI_DateTypeCode.

In practice this won't change the behaviour here as there can be only one DateTypeCode, but makes it easier for me to read.

Use gco:nilReason when datetypecode is missing