### PR TITLE
Update backups to use sensible options for s4cmd upload

### DIFF
--- a/backup/modules/store/s3.sh
+++ b/backup/modules/store/s3.sh
@@ -27,7 +27,7 @@ backup() {
 	backup_key_timestamp=`_generate_date`
 
 	logger_info "Spooling backup to S3 bucket 's3://$bucket_name/$backup_key_timestamp'"
-	s4cmd "$@" --recursive put $_BACKUP_DEST/* s3://$bucket_name/$backup_key_timestamp/
+	s4cmd "$@" --recursive --num-threads=4 --multipart-split-size=26214400 --max-singlepart-upload-size=26214400 put $_BACKUP_DEST/* s3://$bucket_name/$backup_key_timestamp/
 }
 
 # pulls backups from s3 (latest backup)


### PR DESCRIPTION
The defaults are obnoxiously large, which causes MemoryErrors when uploading large backups.

For files under 4.5GB, it attempts to upload these as a single part upload, and tries to load the file into memory.

This change ensures that chunks are never more than 25MB, and caps the threads at 4 (instead of NUM_CPUS * 4), to make the memory usage more predictable and lighter on servers.