### PR TITLE
Fix unit test for dataseturi

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/expected/c1344e70-480e-0993-e044-00144f7bc0f4.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/expected/c1344e70-480e-0993-e044-00144f7bc0f4.xml
@@ -44,4 +44,24 @@
          </cit:title>
       </cit:CI_Citation>
    </mdb:metadataStandard>
+   <mdb:identificationInfo>
+      <mri:MD_DataIdentification>
+         <mri:citation>
+            <cit:CI_Citation>
+               <cit:title gco:nilReason="missing"/>
+               <cit:alternateTitle gco:nilReason="missing"/>
+               <cit:date gco:nilReason="missing"/>
+            </cit:CI_Citation>
+         </mri:citation>
+         <mri:abstract gco:nilReason="missing"/>
+         <mri:defaultLocale>
+            <lan:PT_Locale>
+               <lan:language>
+                  <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+               </lan:language>
+               <lan:characterEncoding gco:nilReason="unknown"/>
+            </lan:PT_Locale>
+         </mri:defaultLocale>
+      </mri:MD_DataIdentification>
+   </mdb:identificationInfo>
 </mdb:MD_Metadata>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/export/c1344e70-480e-0993-e044-00144f7bc0f4/metadata/metadata.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/export/c1344e70-480e-0993-e044-00144f7bc0f4/metadata/metadata.xml
@@ -10,4 +10,19 @@
   <gmd:dataSetURI>
     <gco:CharacterString>http://imos.aodn.org.au/webportal/</gco:CharacterString>
   </gmd:dataSetURI>
+  <gmd:identificationInfo>
+    <mcp:MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title gco:nilReason="missing"/>
+          <gmd:alternateTitle gco:nilReason="missing"/>
+          <gmd:date gco:nilReason="missing"/>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract gco:nilReason="missing"/>
+      <gmd:language>
+        <gco:CharacterString xmlns:srv="http://www.isotc211.org/2005/srv">eng</gco:CharacterString>
+      </gmd:language>
+    </mcp:MD_DataIdentification>
+  </gmd:identificationInfo>
 </mcp:MD_Metadata>


### PR DESCRIPTION
Requires a citation to add an md_identifier to.  All our records have that.