### PR TITLE
Fix dataseturi unit test attempt 2

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/expected/c1344e70-480e-0993-e044-00144f7bc0f4.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/expected/c1344e70-480e-0993-e044-00144f7bc0f4.xml
@@ -51,6 +51,29 @@
                <cit:title gco:nilReason="missing"/>
                <cit:alternateTitle gco:nilReason="missing"/>
                <cit:date gco:nilReason="missing"/>
+               <cit:identifier>
+                  <mcc:MD_Identifier>
+                     <mcc:code>
+                        <gco:CharacterString>http://imos.aodn.org.au/webportal/</gco:CharacterString>
+                     </mcc:code>
+                  </mcc:MD_Identifier>
+               </cit:identifier>
+               <cit:citedResponsibleParty>
+                  <cit:CI_Responsibility>
+                     <cit:role>
+                        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode"
+                                         codeListValue="resourceProvider"/>
+                     </cit:role>
+                     <cit:party>
+                        <cit:CI_Organisation>
+                           <cit:name>
+                              <gco:CharacterString>Integrated Marine Observing System (IMOS)</gco:CharacterString>
+                           </cit:name>
+                           <cit:contactInfo gco:nilReason="missing"/>
+                        </cit:CI_Organisation>
+                     </cit:party>
+                  </cit:CI_Responsibility>
+               </cit:citedResponsibleParty>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract gco:nilReason="missing"/>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/export/c1344e70-480e-0993-e044-00144f7bc0f4/metadata/metadata.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/datasetUri/export/c1344e70-480e-0993-e044-00144f7bc0f4/metadata/metadata.xml
@@ -17,6 +17,17 @@
           <gmd:title gco:nilReason="missing"/>
           <gmd:alternateTitle gco:nilReason="missing"/>
           <gmd:date gco:nilReason="missing"/>
+          <gmd:citedResponsibleParty>
+            <gmd:CI_ResponsibleParty>
+              <gmd:organisationName>
+                <gco:CharacterString>Integrated Marine Observing System (IMOS)</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:contactInfo gco:nilReason="missing"/>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="resourceProvider">resourceProvider</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
         </gmd:CI_Citation>
       </gmd:citation>
       <gmd:abstract gco:nilReason="missing"/>


### PR DESCRIPTION
Apparently requires a citedresponsibility element as well which I removed in my last cleanup just before @APaulic merged it.

Doesn't really make sense to require a citedresponsibility party but leaving that for the moment as again our records should have that.