### PR TITLE
Allow different url substitutions to be applied when migrating records

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/README.md
+++ b/geonetwork/transform-mcp-iso19115-3/README.md
@@ -6,6 +6,7 @@
 - Intended for data exported by gn3-tool.
 - If the `-d` option is specified then the directory will be recursively searched for any file with the name specified by the `-i` option. 
 - The converted file will be created with the name specified by the `-o` option at the same level in the directory structure as the input file.
+- If the `-u` option is specified then url substitutions in the specified configuration file will be applied after the transformation
 
 ## Tool
 
@@ -16,7 +17,7 @@ Options:
 - -d: Directory name containing xml file name at some depth in the directory structure
 - -i: Input xml file name
 - -o: Output xml file name
-- -u: Update resource and metadata linkage urls
+- -u: URL substitutions configuration file
 
 ## Usage
 
@@ -29,7 +30,7 @@ mvn package
 ```
 Note: Make sure `transform-mcp-iso19115-3-1.0-SNAPSHOT-jar-with-dependencies.jar` exists in target folder. 
 ```
-java -jar ./target/transform-mcp-iso19115-3-1.0-SNAPSHOT-jar-with-dependencies.jar -d /tmp/gn-dump-local -i metadata.xml -o metadata.iso19115-3.2018.xml
+java -jar ./target/transform-mcp-iso19115-3-1.0-SNAPSHOT-jar-with-dependencies.jar -d /tmp/gn-dump-local -i metadata.xml -o metadata.iso19115-3.2018.xml -u url-substitutions/imos-prod.xml
 ```
 
 

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/substitute-urls.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/substitute-urls.xsl
@@ -6,28 +6,28 @@
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 version="2.0"
                 exclude-result-prefixes="#all">
-  
+
   <xsl:output indent="yes"/>
 
-  <!-- url substitutions to be performed -->
-  <xsl:variable name="urlSubstitutions">
-    <!-- Stack endpoints -->
-    <substitution match="https?://portal.aodn.org.au" replaceWith="http://portal-gn3-integration.dev.aodn.org.au"/>
-    <substitution match="https?://geoserver.123.aodn.org.au" replaceWith="http://geoserver-gn3-integration.dev.aodn.org.au"/>
-    <substitution match="https?://thredds.aodn.org.au" replaceWith="http://thredds-gn3-integration.dev.aodn.org.au"/>
-    <substitution match="https?://tilecache.aodn.org.au" replaceWith="http://tilecache-gn3-integration.dev.aodn.org.au"/>
-    <substitution match="https?://processes.aodn.org.au" replaceWith="https://processes-gn3-integration.dev.aodn.org.au"/>
-    <!-- Instance keyword thesauri links -->
-    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus" replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/eng/thesaurus"/>
-    <!-- Instance point of truth links --> 
-    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid=" replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/"/>
-    <!-- Instance references to metadata -->
-    <substitution match="https?://catalogue-123.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid=" replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/"/>
-    <!-- Instance download links - no disclaimer option - just change to download link for the moment until we work out what we're going to do about that -->
-    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private" replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/$2/attachments/$3"/>
-  </xsl:variable>
+  <xsl:param name="configFile"/>
+
+  <!-- load url substitutions to be performed -->
+  <xsl:variable name="urlSubstitutions" select="document($configFile)/urlSubstitutions"/>
 
   <xsl:variable name="urlSubstitutionSelector" select="string-join($urlSubstitutions/substitution/@match, '|')"/>
+
+  <xsl:template match="/">
+    <!-- abort if we can't load the url substitutions file or there are no substitutions -->
+    <xsl:if test="not(doc-available($configFile))">
+        <xsl:message terminate="yes" select="concat('Could not load url substitutions configuration file: ', $configFile)"/>
+    </xsl:if>
+    <!-- abort if there are no substitutions to apply -->
+    <xsl:if test="not($urlSubstitutionSelector)">
+        <xsl:message terminate="yes" select="concat('No substitutions specified in: ', $configFile)"/>
+    </xsl:if>
+    <!-- All good - apply templates -->
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
 
   <!-- default action is to copy -->
   <xsl:template match="@*|node()">

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-prod.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-prod.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-imos -->
+<!-- instance to the new GN3 production catalogue-imos instance -->
+
+<urlSubstitutions>
+    <!-- Instance keyword thesauri links - map old links used to a consistent GN3 link -->
+    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
+            replaceWith="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/eng/thesaurus"/>
+
+    <!-- Instance point of truth links - map the GN2 endpoint to the GN3 endpoint -->
+    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
+            replaceWith="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/api/records/"/>
+
+    <!-- References to old url - map references to the old geonetwork endpoint to the GN3 endpoint  -->
+    <substitution match="https?://catalogue-123.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
+            replaceWith="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/api/records/"/>
+
+    <!-- Instance download links  - map the GN2 endpoint to the GN3 enpoint -->
+    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
+            replaceWith="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/api/records/$2/attachments/$3"/>
+</urlSubstitutions>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-test.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-imos -->
+<!-- instance to the GN3  catalogue-imos integration testing instance -->
+
+<urlSubstitutions>
+    <!-- Stack endpoints -->
+    <substitution match="https?://portal.aodn.org.au"
+            replaceWith="http://portal-gn3-integration.dev.aodn.org.au"/>
+    <substitution match="https?://geoserver.123.aodn.org.au"
+            replaceWith="http://geoserver-gn3-integration.dev.aodn.org.au"/>
+    <substitution match="https?://thredds.aodn.org.au"
+            replaceWith="http://thredds-gn3-integration.dev.aodn.org.au"/>
+    <substitution match="https?://tilecache.aodn.org.au"
+            replaceWith="http://tilecache-gn3-integration.dev.aodn.org.au"/>
+    <substitution match="https?://processes.aodn.org.au"
+            replaceWith="https://processes-gn3-integration.dev.aodn.org.au"/>
+
+    <!-- Instance keyword thesauri links -->
+    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
+            replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/eng/thesaurus"/>
+
+    <!-- Instance point of truth links -->
+    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
+            replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/"/>
+
+    <!-- References to old url -->
+    <substitution match="https?://catalogue-123.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
+            replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/"/>
+
+    <!-- Instance download links -->
+    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
+            replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/$2/attachments/$3"/>
+</urlSubstitutions>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-prod.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-prod.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-rc -->
+<!-- instance to the GN3 catalogue-rc test instance -->
+
+<urlSubstitutions>
+    <!-- Instance keyword thesauri links -->
+    <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
+            replaceWith="https://catalogue-rc.aodn.org.au:443/geonetwork/srv/eng/thesaurus"/>
+
+    <!-- Instance point of truth links -->
+    <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
+            replaceWith="https://catalogue-rc.aodn.org.au:443/geonetwork/srv/api/records/"/>
+
+    <!-- Instance download links -->
+    <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
+            replaceWith="https://catalogue-rc.aodn.org.au:433/geonetwork/srv/api/records/$2/attachments/$3"/>
+</urlSubstitutions>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-test.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-rc -->
+<!-- instance to the GN3 catalogue-rc test instance -->
+
+<urlSubstitutions>
+    <!-- Instance keyword thesauri links -->
+    <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
+            replaceWith="http://geonetwork3-ci-catalogue-rc.dev.aodn.org.au/geonetwork/srv/eng/thesaurus"/>
+
+    <!-- Instance point of truth links -->
+    <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
+            replaceWith="http://geonetwork3-ci-catalogue-rc.dev.aodn.org.au/geonetwork/srv/api/records/"/>
+
+    <!-- Instance download links -->
+    <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
+            replaceWith="http://geonetwork3-ci-catalogue-rc.dev.aodn.org.au/geonetwork/srv/api/records/$2/attachments/$3"/>
+</urlSubstitutions>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/java/au/org/aodn/xslt/TransformCatalogueTest.java
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/java/au/org/aodn/xslt/TransformCatalogueTest.java
@@ -161,7 +161,16 @@ public class TransformCatalogueTest {
         testFiles("environmentDescription");
     }
 
+    @Test
+    public void testProdSubstitutions() throws IOException {
+        testFiles("prodSubstitutions", "url-substitutions/imos-prod.xml");
+    }
+
     private void testFiles(String testSubDirName) throws IOException {
+        testFiles(testSubDirName, "url-substitutions/imos-test.xml");
+    }
+
+    private void testFiles(String testSubDirName, String urlSubstitutionsFile) throws IOException {
         Path resourceSubDir = resourceDir.resolve(testSubDirName + "/export");
         // Copy test files to test directory
         copyFolder(resourceSubDir, testDir);
@@ -172,7 +181,7 @@ public class TransformCatalogueTest {
                 "-d", testDir.toString(),
                 "-i", "metadata.xml",
                 "-o", "metadata.iso19115-3.2018.xml",
-                "-u"
+                "-u", urlSubstitutionsFile
         };
         TransformCatalogue.main(args);
         // Assert each test result matches expected result

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/expected/4402cb50-e20a-44ee-93e6-4728259250d2.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/expected/4402cb50-e20a-44ee-93e6-4728259250d2.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdb:MD_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
+                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+                 xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
+                 xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
+                 xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                 xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+                 xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
+                 xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                 xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/1.0"
+                 xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/1.0"
+                 xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
+                 xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+                 xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
+                 xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                 xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                 xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                 xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
+                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
+                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
+                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xsi:schemaLocation="http://standards.iso.org/iso/19115/-3/cat/1.0 http://standards.iso.org/iso/19115/-3/cat/1.0/cat.xsd http://standards.iso.org/iso/19115/-3/cit/2.0 http://standards.iso.org/iso/19115/-3/cit/2.0/cit.xsd http://standards.iso.org/iso/19115/-3/gcx/1.0 http://standards.iso.org/iso/19115/-3/gcx/1.0/gcx.xsd http://standards.iso.org/iso/19115/-3/gex/1.0 http://standards.iso.org/iso/19115/-3/gex/1.0/gex.xsd http://standards.iso.org/iso/19115/-3/lan/1.0 http://standards.iso.org/iso/19115/-3/lan/1.0/lan.xsd http://standards.iso.org/iso/19115/-3/srv/2.0 http://standards.iso.org/iso/19115/-3/srv/2.0/srv.xsd http://standards.iso.org/iso/19115/-3/mas/1.0 http://standards.iso.org/iso/19115/-3/mas/1.0/mas.xsd http://standards.iso.org/iso/19115/-3/mcc/1.0 http://standards.iso.org/iso/19115/-3/mcc/1.0/mcc.xsd http://standards.iso.org/iso/19115/-3/mco/1.0 http://standards.iso.org/iso/19115/-3/mco/1.0/mco.xsd http://standards.iso.org/iso/19115/-3/mda/2.0 http://standards.iso.org/iso/19115/-3/mda/2.0/mda.xsd http://standards.iso.org/iso/19115/-3/mdb/2.0 http://standards.iso.org/iso/19115/-3/mdb/2.0/mdb.xsd http://standards.iso.org/iso/19115/-3/mds/2.0 http://standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd http://standards.iso.org/iso/19115/-3/mdt/2.0 http://standards.iso.org/iso/19115/-3/mdt/2.0/mdt.xsd http://standards.iso.org/iso/19115/-3/mex/1.0 http://standards.iso.org/iso/19115/-3/mex/1.0/mex.xsd http://standards.iso.org/iso/19115/-3/mmi/1.0 http://standards.iso.org/iso/19115/-3/mmi/1.0/mmi.xsd http://standards.iso.org/iso/19115/-3/mpc/1.0 http://standards.iso.org/iso/19115/-3/mpc/1.0/mpc.xsd http://standards.iso.org/iso/19115/-3/mrc/2.0 http://standards.iso.org/iso/19115/-3/mrc/2.0/mrc.xsd http://standards.iso.org/iso/19115/-3/mrd/1.0 http://standards.iso.org/iso/19115/-3/mrd/1.0/mrd.xsd http://standards.iso.org/iso/19115/-3/mri/1.0 http://standards.iso.org/iso/19115/-3/mri/1.0/mri.xsd http://standards.iso.org/iso/19115/-3/mrl/2.0 http://standards.iso.org/iso/19115/-3/mrl/2.0/mrl.xsd http://standards.iso.org/iso/19115/-3/mrs/1.0 http://standards.iso.org/iso/19115/-3/mrs/1.0/mrs.xsd http://standards.iso.org/iso/19115/-3/msr/2.0 http://standards.iso.org/iso/19115/-3/msr/2.0/msr.xsd http://standards.iso.org/iso/19157/-2/mdq/1.0 http://standards.iso.org/iso/19157/-2/mdq/1.0/mdq.xsd http://standards.iso.org/iso/19115/-3/mac/2.0 http://standards.iso.org/iso/19115/-3/mac/2.0/mac.xsd http://standards.iso.org/iso/19115/-3/gco/1.0 http://standards.iso.org/iso/19115/-3/gco/1.0/gco.xsd http://standards.iso.org/iso/19115/-3/gmw/1.0 http://standards.iso.org/iso/19115/-3/gmw/1.0/gmw.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://www.w3.org/1999/xlink http://www.w3.org/1999/xlink.xsd">
+   <mdb:metadataIdentifier>
+      <mcc:MD_Identifier>
+         <mcc:code>
+            <gco:CharacterString>4402cb50-e20a-44ee-93e6-4728259250d2</gco:CharacterString>
+         </mcc:code>
+      </mcc:MD_Identifier>
+   </mdb:metadataIdentifier>
+   <mdb:contact gco:nilReason="missing"/>
+   <mdb:dateInfo gco:nilReason="missing"/>
+   <mdb:metadataStandard>
+      <cit:CI_Citation>
+         <cit:title>
+            <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
+         </cit:title>
+      </cit:CI_Citation>
+   </mdb:metadataStandard>
+   <mdb:metadataLinkage>
+      <cit:CI_OnlineResource>
+         <cit:linkage>
+            <gco:CharacterString>https://catalogue-imos.aodn.org.au:443/geonetwork/srv/api/records/4402cb50-e20a-44ee-93e6-4728259250d2</gco:CharacterString>
+         </cit:linkage>
+         <cit:protocol>
+            <gco:CharacterString>WWW:LINK-1.0-http--metadata-URL</gco:CharacterString>
+         </cit:protocol>
+         <cit:description>
+            <gco:CharacterString>Point of truth URL of this metadata record</gco:CharacterString>
+         </cit:description>
+      </cit:CI_OnlineResource>
+   </mdb:metadataLinkage>
+   <mdb:identificationInfo>
+      <mri:MD_DataIdentification>
+         <mri:citation gco:nilReason="missing"/>
+         <mri:abstract gco:nilReason="missing"/>
+         <mri:descriptiveKeywords>
+            <mri:MD_Keywords>
+               <mri:keyword>
+                  <gco:CharacterString>Argo Floats Facility, Integrated Marine Observing System (IMOS)</gco:CharacterString>
+               </mri:keyword>
+               <mri:type>
+                  <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="discipline"/>
+               </mri:type>
+               <mri:thesaurusName>
+                  <cit:CI_Citation>
+                     <cit:title>
+                        <gco:CharacterString>AODN Organisation Vocabulary</gco:CharacterString>
+                     </cit:title>
+                     <cit:date>
+                        <cit:CI_Date>
+                           <cit:date>
+                              <gco:DateTime>2018-07-13T11:07:00</gco:DateTime>
+                           </cit:date>
+                           <cit:dateType>
+                              <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                                                   codeListValue="publication"/>
+                           </cit:dateType>
+                        </cit:CI_Date>
+                     </cit:date>
+                     <cit:identifier>
+                        <mcc:MD_Identifier>
+                           <mcc:code>
+                              <gcx:Anchor xlink:href="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/eng/thesaurus.download?ref=external.discipline.aodnorganisationvocabulary_unpublished_for_IMOS_keywords">geonetwork.thesaurus.external.discipline.aodnorganisationvocabulary_unpublished_for_IMOS_keywords</gcx:Anchor>
+                           </mcc:code>
+                        </mcc:MD_Identifier>
+                     </cit:identifier>
+                  </cit:CI_Citation>
+               </mri:thesaurusName>
+            </mri:MD_Keywords>
+         </mri:descriptiveKeywords>
+         <mri:defaultLocale>
+            <lan:PT_Locale>
+               <lan:language>
+                  <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+               </lan:language>
+               <lan:characterEncoding gco:nilReason="unknown"/>
+            </lan:PT_Locale>
+         </mri:defaultLocale>
+      </mri:MD_DataIdentification>
+   </mdb:identificationInfo>
+   <mdb:distributionInfo>
+      <mrd:MD_Distribution>
+         <mrd:distributionFormat gco:nilReason="missing"/>
+         <mrd:transferOptions>
+            <mrd:MD_DigitalTransferOptions>
+               <mrd:onLine>
+                  <cit:CI_OnlineResource>
+                     <cit:linkage>
+                        <gco:CharacterString>http://geoserver-123.aodn.org.au/geoserver/wms</gco:CharacterString>
+                     </cit:linkage>
+                     <cit:protocol>
+                        <gco:CharacterString>OGC:WMS-1.1.1-http-get-map</gco:CharacterString>
+                     </cit:protocol>
+                     <cit:name>
+                        <gco:CharacterString>imos:argo_profile_map</gco:CharacterString>
+                     </cit:name>
+                     <cit:description>
+                        <gco:CharacterString>Argo Profiles</gco:CharacterString>
+                     </cit:description>
+                  </cit:CI_OnlineResource>
+               </mrd:onLine>
+               <mrd:onLine>
+                  <cit:CI_OnlineResource>
+                     <cit:linkage>
+                        <gco:CharacterString>https://catalogue-imos.aodn.org.au:443/geonetwork/srv/api/records/9e5c3031-a026-48b3-a153-a70c2e2b78b9/attachments/Bronte_Tilbrook_730_report_050808.wmv</gco:CharacterString>
+                     </cit:linkage>
+                     <cit:protocol>
+                        <gco:CharacterString>WWW:DOWNLOAD-1.0-http--downloadother</gco:CharacterString>
+                     </cit:protocol>
+                     <cit:name>
+                        <gcx:MimeFileType type="audio/x-ms-wmv">Bronte_Tilbrook_730_report_050808.wmv</gcx:MimeFileType>
+                     </cit:name>
+                     <cit:description>
+                        <gco:CharacterString>Video file (wmv): Research Leader Bronte Tilbrook on the ABC 7:30 Report</gco:CharacterString>
+                     </cit:description>
+                  </cit:CI_OnlineResource>
+               </mrd:onLine>
+            </mrd:MD_DigitalTransferOptions>
+         </mrd:transferOptions>
+      </mrd:MD_Distribution>
+   </mdb:distributionInfo>
+</mdb:MD_Metadata>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/export/4402cb50-e20a-44ee-93e6-4728259250d2/info.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/export/4402cb50-e20a-44ee-93e6-4728259250d2/info.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<info version="1.1">
+  <general>
+    <createDate>2013-08-26T14:20:06</createDate>
+    <changeDate>2020-04-30T22:22:30</changeDate>
+    <schema>iso19139.mcp-2.0</schema>
+    <isTemplate>false</isTemplate>
+    <localId>24277</localId>
+    <format>full</format>
+    <rating>5</rating>
+    <popularity>22685</popularity>
+    <uuid>4402cb50-e20a-44ee-93e6-4728259250d2</uuid>
+    <siteId>5c6d6b45-1659-435c-91a7-4147caeed8a4</siteId>
+    <siteName>Catalogue for the 123 Portal</siteName>
+  </general>
+  <categories />
+  <privileges>
+    <group name="all">
+      <operation name="view" />
+      <operation name="download" />
+      <operation name="dynamic" />
+      <operation name="featured" />
+    </group>
+  </privileges>
+  <public />
+  <private />
+  <owner name="atkinsn" />
+</info>
+

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/export/4402cb50-e20a-44ee-93e6-4728259250d2/metadata/metadata.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/export/4402cb50-e20a-44ee-93e6-4728259250d2/metadata/metadata.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mcp:MD_Metadata xmlns:mcp="http://schemas.aodn.org.au/mcp-2.0" xmlns:dwc="http://rs.tdwg.org/dwc/terms/" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gml="http://www.opengis.net/gml" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://schemas.aodn.org.au/mcp-2.0 http://schemas.aodn.org.au/mcp-2.0/schema.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd http://rs.tdwg.org/dwc/terms/ http://schemas.aodn.org.au/mcp-2.0/mcpDwcTerms.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>4402cb50-e20a-44ee-93e6-4728259250d2</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:contact gco:nilReason="missing">
+  </gmd:contact>
+  <gmd:dateStamp gco:nilReason="missing">
+  </gmd:dateStamp>
+  <gmd:identificationInfo>
+    <mcp:MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation gco:nilReason="missing"/>
+      <gmd:abstract gco:nilReason="missing"/>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>Argo Floats Facility, Integrated Marine Observing System (IMOS)</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="discipline">discipline</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>AODN Organisation Vocabulary</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:DateTime>2018-07-13T11:07:00</gco:DateTime>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/en/thesaurus.download?ref=external.discipline.aodnorganisationvocabulary_unpublished_for_IMOS_keywords">geonetwork.thesaurus.external.discipline.aodnorganisationvocabulary_unpublished_for_IMOS_keywords</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:language>
+        <gco:CharacterString xmlns:srv="http://www.isotc211.org/2005/srv">eng</gco:CharacterString>
+      </gmd:language>
+    </mcp:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat gco:nilReason="missing"/>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://catalogue-imos.aodn.org.au:443/geonetwork/srv/en/metadata.show?uuid=4402cb50-e20a-44ee-93e6-4728259250d2</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--metadata-URL</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:description>
+                <gco:CharacterString>Point of truth URL of this metadata record</gco:CharacterString>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>http://geoserver-123.aodn.org.au/geoserver/wms</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WMS-1.1.1-http-get-map</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>imos:argo_profile_map</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Argo Profiles</gco:CharacterString>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://catalogue-imos.aodn.org.au:443/geonetwork/srv/en/file.disclaimer?uuid=9e5c3031-a026-48b3-a153-a70c2e2b78b9&amp;fname=Bronte_Tilbrook_730_report_050808.wmv&amp;access=private</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--downloadother</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gmx:MimeFileType type="audio/x-ms-wmv">Bronte_Tilbrook_730_report_050808.wmv</gmx:MimeFileType>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Video file (wmv): Research Leader Bronte Tilbrook on the ABC 7:30 Report</gco:CharacterString>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+</mcp:MD_Metadata>


### PR DESCRIPTION
In particular prod urls (https://github.com/aodn/backlog/issues/1565), rc test urls and rc prod urls