### PR TITLE
Make thumbnail references work in GN3

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-prod.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-prod.xml
@@ -3,7 +3,9 @@
 <!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-imos -->
 <!-- instance to the new GN3 production catalogue-imos instance -->
 
-<urlSubstitutions>
+<config>
+    <url>https://catalogue-imos.aodn.org.au:443/geonetwork/srv</url>
+
     <!-- Instance keyword thesauri links - map old links used to a consistent GN3 link -->
     <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
             replaceWith="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/eng/thesaurus"/>
@@ -19,4 +21,4 @@
     <!-- Instance download links  - map the GN2 endpoint to the GN3 enpoint -->
     <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
             replaceWith="https://catalogue-imos.aodn.org.au:443/geonetwork/srv/api/records/$2/attachments/$3"/>
-</urlSubstitutions>
+</config>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-test.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/imos-test.xml
@@ -3,7 +3,9 @@
 <!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-imos -->
 <!-- instance to the GN3  catalogue-imos integration testing instance -->
 
-<urlSubstitutions>
+<config>
+    <url>http://catalogue-imos.dev.aodn.org.au/geonetwork/srv</url>
+
     <!-- Stack endpoints -->
     <substitution match="https?://portal.aodn.org.au"
             replaceWith="http://portal-gn3-integration.dev.aodn.org.au"/>
@@ -31,4 +33,4 @@
     <!-- Instance download links -->
     <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
             replaceWith="http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/$2/attachments/$3"/>
-</urlSubstitutions>
+</config>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-prod.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-prod.xml
@@ -3,7 +3,9 @@
 <!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-rc -->
 <!-- instance to the GN3 catalogue-rc test instance -->
 
-<urlSubstitutions>
+<config>
+    <url>https://catalogue-rc.aodn.org.au:443/geonetwork/srv</url>
+
     <!-- Instance keyword thesauri links -->
     <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
             replaceWith="https://catalogue-rc.aodn.org.au:443/geonetwork/srv/eng/thesaurus"/>
@@ -15,4 +17,4 @@
     <!-- Instance download links -->
     <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
             replaceWith="https://catalogue-rc.aodn.org.au:433/geonetwork/srv/api/records/$2/attachments/$3"/>
-</urlSubstitutions>
+</config>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-test.xml
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/process/url-substitutions/rc-test.xml
@@ -3,7 +3,9 @@
 <!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-rc -->
 <!-- instance to the GN3 catalogue-rc test instance -->
 
-<urlSubstitutions>
+<config>
+    <url>http://geonetwork3-ci-catalogue-rc.dev.aodn.org.au/geonetwork/srv</url>
+
     <!-- Instance keyword thesauri links -->
     <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
             replaceWith="http://geonetwork3-ci-catalogue-rc.dev.aodn.org.au/geonetwork/srv/eng/thesaurus"/>
@@ -15,4 +17,4 @@
     <!-- Instance download links -->
     <substitution match="https?://catalogue-rc.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
             replaceWith="http://geonetwork3-ci-catalogue-rc.dev.aodn.org.au/geonetwork/srv/api/records/$2/attachments/$3"/>
-</urlSubstitutions>
+</config>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/597351b5-7bce-44ac-aa04-5e59e5abb5e2.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/597351b5-7bce-44ac-aa04-5e59e5abb5e2.xml
@@ -672,7 +672,7 @@
          <mri:graphicOverview>
             <mcc:MD_BrowseGraphic>
                <mcc:fileName>
-                  <gco:CharacterString>southern_surveyor_pic_s.png</gco:CharacterString>
+                  <gco:CharacterString>http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/597351b5-7bce-44ac-aa04-5e59e5abb5e2/attachments/southern_surveyor_pic_s.png</gco:CharacterString>
                </mcc:fileName>
                <mcc:fileDescription>
                   <gco:CharacterString>thumbnail</gco:CharacterString>
@@ -685,7 +685,7 @@
          <mri:graphicOverview>
             <mcc:MD_BrowseGraphic>
                <mcc:fileName>
-                  <gco:CharacterString>southern_surveyor_pic.png</gco:CharacterString>
+                  <gco:CharacterString>http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/597351b5-7bce-44ac-aa04-5e59e5abb5e2/attachments/southern_surveyor_pic.png</gco:CharacterString>
                </mcc:fileName>
                <mcc:fileDescription>
                   <gco:CharacterString>large_thumbnail</gco:CharacterString>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/63db5801-cc19-40ef-83b3-85ccba884cf7.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/63db5801-cc19-40ef-83b3-85ccba884cf7.xml
@@ -646,7 +646,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
          <mri:graphicOverview>
             <mcc:MD_BrowseGraphic>
                <mcc:fileName>
-                  <gco:CharacterString>southern_surveyor_pic_s.png</gco:CharacterString>
+                  <gco:CharacterString>http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/63db5801-cc19-40ef-83b3-85ccba884cf7/attachments/southern_surveyor_pic_s.png</gco:CharacterString>
                </mcc:fileName>
                <mcc:fileDescription>
                   <gco:CharacterString>thumbnail</gco:CharacterString>
@@ -659,7 +659,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
          <mri:graphicOverview>
             <mcc:MD_BrowseGraphic>
                <mcc:fileName>
-                  <gco:CharacterString>southern_surveyor_pic.png</gco:CharacterString>
+                  <gco:CharacterString>http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/63db5801-cc19-40ef-83b3-85ccba884cf7/attachments/southern_surveyor_pic.png</gco:CharacterString>
                </mcc:fileName>
                <mcc:fileDescription>
                   <gco:CharacterString>large_thumbnail</gco:CharacterString>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -485,7 +485,7 @@
          <mri:graphicOverview>
             <mcc:MD_BrowseGraphic>
                <mcc:fileName>
-                  <gco:CharacterString>SOOP-Bounding-Box_s.png</gco:CharacterString>
+                  <gco:CharacterString>http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/8af21108-c535-43bf-8dab-c1f45a26088c/attachments/SOOP-Bounding-Box_s.png</gco:CharacterString>
                </mcc:fileName>
                <mcc:fileDescription>
                   <gco:CharacterString>thumbnail</gco:CharacterString>
@@ -498,7 +498,7 @@
          <mri:graphicOverview>
             <mcc:MD_BrowseGraphic>
                <mcc:fileName>
-                  <gco:CharacterString>SOOP-Bounding-Box.png</gco:CharacterString>
+                  <gco:CharacterString>http://catalogue-imos.dev.aodn.org.au/geonetwork/srv/api/records/8af21108-c535-43bf-8dab-c1f45a26088c/attachments/SOOP-Bounding-Box.png</gco:CharacterString>
                </mcc:fileName>
                <mcc:fileDescription>
                   <gco:CharacterString>large_thumbnail</gco:CharacterString>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/expected/4402cb50-e20a-44ee-93e6-4728259250d2.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/expected/4402cb50-e20a-44ee-93e6-4728259250d2.xml
@@ -61,6 +61,32 @@
       <mri:MD_DataIdentification>
          <mri:citation gco:nilReason="missing"/>
          <mri:abstract gco:nilReason="missing"/>
+         <mri:graphicOverview>
+            <mcc:MD_BrowseGraphic>
+               <mcc:fileName>
+                  <gco:CharacterString>https://catalogue-imos.aodn.org.au:443/geonetwork/srv/api/records/4402cb50-e20a-44ee-93e6-4728259250d2/attachments/southern_surveyor_pic_s.png</gco:CharacterString>
+               </mcc:fileName>
+               <mcc:fileDescription>
+                  <gco:CharacterString>thumbnail</gco:CharacterString>
+               </mcc:fileDescription>
+               <mcc:fileType>
+                  <gco:CharacterString>png</gco:CharacterString>
+               </mcc:fileType>
+            </mcc:MD_BrowseGraphic>
+         </mri:graphicOverview>
+         <mri:graphicOverview>
+            <mcc:MD_BrowseGraphic>
+               <mcc:fileName>
+                  <gco:CharacterString>http://www.marlin.csiro.au:80/geonetwork/srv/eng/resources.get?uuid=c3c9663f-50ba-41c9-b1ac-b5a9b7e9d4f7&amp;fname=imos_abd_data_oview.png</gco:CharacterString>
+               </mcc:fileName>
+               <mcc:fileDescription>
+                  <gco:CharacterString>large_thumbnail</gco:CharacterString>
+               </mcc:fileDescription>
+               <mcc:fileType>
+                  <gco:CharacterString>png</gco:CharacterString>
+               </mcc:fileType>
+            </mcc:MD_BrowseGraphic>
+         </mri:graphicOverview>
          <mri:descriptiveKeywords>
             <mri:MD_Keywords>
                <mri:keyword>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/export/4402cb50-e20a-44ee-93e6-4728259250d2/metadata/metadata.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/prodSubstitutions/export/4402cb50-e20a-44ee-93e6-4728259250d2/metadata/metadata.xml
@@ -12,6 +12,32 @@
     <mcp:MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
       <gmd:citation gco:nilReason="missing"/>
       <gmd:abstract gco:nilReason="missing"/>
+      <gmd:graphicOverview>
+        <gmd:MD_BrowseGraphic>
+          <gmd:fileName>
+            <gco:CharacterString>southern_surveyor_pic_s.png</gco:CharacterString>
+          </gmd:fileName>
+          <gmd:fileDescription>
+            <gco:CharacterString>thumbnail</gco:CharacterString>
+          </gmd:fileDescription>
+          <gmd:fileType>
+            <gco:CharacterString>png</gco:CharacterString>
+          </gmd:fileType>
+        </gmd:MD_BrowseGraphic>
+      </gmd:graphicOverview>
+      <gmd:graphicOverview>
+        <gmd:MD_BrowseGraphic>
+          <gmd:fileName>
+            <gco:CharacterString>http://www.marlin.csiro.au:80/geonetwork/srv/eng/resources.get?uuid=c3c9663f-50ba-41c9-b1ac-b5a9b7e9d4f7&amp;fname=imos_abd_data_oview.png</gco:CharacterString>
+          </gmd:fileName>
+          <gmd:fileDescription>
+            <gco:CharacterString>large_thumbnail</gco:CharacterString>
+          </gmd:fileDescription>
+          <gmd:fileType>
+            <gco:CharacterString>png</gco:CharacterString>
+          </gmd:fileType>
+        </gmd:MD_BrowseGraphic>
+      </gmd:graphicOverview>
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
           <gmd:keyword>


### PR DESCRIPTION
GN2 assumes relative thumbnail references.  GN3 requires full url's