### PR TITLE
Map online resource description to name field if name field is empty

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/core.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/core.xsl
@@ -716,6 +716,7 @@
   <xsl:include href="mcpsamplingfrequency.xsl"/>
   <xsl:include href="mcpaggregationinfo.xsl"/>
   <xsl:include href="mcpdataparameters_descriptiveKeywords_aodn.xsl"/>
+  <xsl:include href="online-resource-imos.xsl"/>
 
   <!--
     Empty High-Priority Templates to prevent

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/online-resource-imos.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/online-resource-imos.xsl
@@ -1,0 +1,25 @@
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                exclude-result-prefixes="#all">
+
+  <!-- Map description to name if name is empty and description isn't -->
+
+  <xsl:template match="gmd:CI_OnlineResource[normalize-space(gmd:name/*)='' and normalize-space(gmd:description/*)!='']"
+                mode="from19139to19115-3"
+                priority="100">
+    <xsl:element name="cit:CI_OnlineResource">
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates select="gmd:linkage" mode="from19139to19115-3"/>
+      <xsl:apply-templates select="gmd:protocol" mode="from19139to19115-3"/>
+      <xsl:apply-templates select="gmd:applicationProfile" mode="from19139to19115-3"/>
+      <xsl:element name="cit:name">
+        <xsl:apply-templates select="gmd:description/(@*|node())" mode="from19139to19115-3"/>
+      </xsl:element>
+      <xsl:apply-templates select="gmd:function" mode="from19139to19115-3"/>
+    </xsl:element>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/java/au/org/aodn/xslt/TransformCatalogueTest.java
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/java/au/org/aodn/xslt/TransformCatalogueTest.java
@@ -107,6 +107,11 @@ public class TransformCatalogueTest {
     }
 
     @Test
+    public void testOnlineResource() throws IOException {
+        testFiles("onlineResource");
+    }
+
+    @Test
     public void testSamplingFrequency() throws IOException {
         testFiles("samplingFrequency");
     }

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/acquisitionInformation/expected/af5d0ff9-bb9c-4b7c-a63c-854a630b6984.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/acquisitionInformation/expected/af5d0ff9-bb9c-4b7c-a63c-854a630b6984.xml
@@ -202,7 +202,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e21">
+                        <gml:BaseUnit gml:id="d20e21">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPAA</gml:identifier>
                            <gml:name>Degrees Celsius</gml:name>
                            <gml:unitsSystem/>
@@ -220,7 +220,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e67">
+                        <gml:BaseUnit gml:id="d20e67">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UMMC</gml:identifier>
                            <gml:name>Milligrams per cubic metre</gml:name>
                            <gml:unitsSystem/>
@@ -238,7 +238,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e113">
+                        <gml:BaseUnit gml:id="d20e113">
                            <gml:identifier codeSpace="unknown">http://vocab.aodn.org.au/def/unitsofmeasure/entity/481</gml:identifier>
                            <gml:name>Practical Salinity Unit</gml:name>
                            <gml:unitsSystem/>
@@ -256,7 +256,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e159">
+                        <gml:BaseUnit gml:id="d20e159">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPPB</gml:identifier>
                            <gml:name>Parts per billion</gml:name>
                            <gml:unitsSystem/>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/2d2b2f92-12fa-4330-a480-94f0892c2b72.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/2d2b2f92-12fa-4330-a480-94f0892c2b72.xml
@@ -125,12 +125,9 @@
                            <cit:protocol>
                               <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                            </cit:protocol>
-                           <cit:name gco:nilReason="missing">
-                              <gco:CharacterString/>
-                           </cit:name>
-                           <cit:description>
+                           <cit:name>
                               <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                           </cit:description>
+                           </cit:name>
                         </cit:CI_OnlineResource>
                      </cit:onlineResource>
                   </cit:CI_Contact>
@@ -1861,7 +1858,7 @@ Richardson AJ, Walne AW, John AWG, Jonas TD, Lindley JA, Sims DW, Stevens D, Wit
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e904">
+                        <gml:BaseUnit gml:id="d20e904">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPAA</gml:identifier>
                            <gml:name>Degrees Celsius</gml:name>
                            <gml:unitsSystem/>
@@ -1879,7 +1876,7 @@ Richardson AJ, Walne AW, John AWG, Jonas TD, Lindley JA, Sims DW, Stevens D, Wit
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e928">
+                        <gml:BaseUnit gml:id="d20e928">
                            <gml:identifier codeSpace="unknown">http://vocab.aodn.org.au/def/unitsofmeasure/entity/481</gml:identifier>
                            <gml:name>Practical Salinity Unit</gml:name>
                            <gml:unitsSystem/>
@@ -1897,7 +1894,7 @@ Richardson AJ, Walne AW, John AWG, Jonas TD, Lindley JA, Sims DW, Stevens D, Wit
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e952">
+                        <gml:BaseUnit gml:id="d20e952">
                            <gml:identifier codeSpace="unknown"/>
                            <gml:name/>
                            <gml:unitsSystem/>
@@ -1937,12 +1934,9 @@ Richardson AJ, Walne AW, John AWG, Jonas TD, Lindley JA, Sims DW, Stevens D, Wit
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Database snapshot</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1953,12 +1947,9 @@ Richardson AJ, Walne AW, John AWG, Jonas TD, Lindley JA, Sims DW, Stevens D, Wit
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Master Species List</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1969,12 +1960,9 @@ Richardson AJ, Walne AW, John AWG, Jonas TD, Lindley JA, Sims DW, Stevens D, Wit
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Data Paper in Scientific Data</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
             </mrd:MD_DigitalTransferOptions>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/4a97bd11-e821-4682-8b20-cb69201f3223.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/4a97bd11-e821-4682-8b20-cb69201f3223.xml
@@ -126,12 +126,9 @@
                            <cit:protocol>
                               <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                            </cit:protocol>
-                           <cit:name gco:nilReason="missing">
-                              <gco:CharacterString/>
-                           </cit:name>
-                           <cit:description>
+                           <cit:name>
                               <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                           </cit:description>
+                           </cit:name>
                         </cit:CI_OnlineResource>
                      </cit:onlineResource>
                   </cit:CI_Contact>
@@ -289,12 +286,9 @@
                                        <cit:protocol>
                                           <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                        </cit:protocol>
-                                       <cit:name gco:nilReason="missing">
-                                          <gco:CharacterString/>
-                                       </cit:name>
-                                       <cit:description>
+                                       <cit:name>
                                           <gco:CharacterString>Website for the Integrated Marine Observing System</gco:CharacterString>
-                                       </cit:description>
+                                       </cit:name>
                                     </cit:CI_OnlineResource>
                                  </cit:onlineResource>
                               </cit:CI_Contact>
@@ -314,12 +308,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Website for the Integrated Marine Observing System</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
             </cit:CI_Citation>
@@ -468,12 +459,9 @@
                                  <cit:protocol>
                                     <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                  </cit:protocol>
-                                 <cit:name gco:nilReason="missing">
-                                    <gco:CharacterString/>
-                                 </cit:name>
-                                 <cit:description>
+                                 <cit:name>
                                     <gco:CharacterString>Macquarie University staff profile for Rob Harcourt</gco:CharacterString>
-                                 </cit:description>
+                                 </cit:name>
                               </cit:CI_OnlineResource>
                            </cit:onlineResource>
                         </cit:CI_Contact>
@@ -1385,7 +1373,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e675">
+                        <gml:BaseUnit gml:id="d20e675">
                            <gml:identifier codeSpace="unknown"/>
                            <gml:name/>
                            <gml:unitsSystem/>
@@ -1403,7 +1391,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e706">
+                        <gml:BaseUnit gml:id="d20e706">
                            <gml:identifier codeSpace="unknown"/>
                            <gml:name/>
                            <gml:unitsSystem/>
@@ -1443,12 +1431,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Acoustic page on IMOS website</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1475,12 +1460,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>View and download data though the AODN Portal</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1492,11 +1474,8 @@
                         <gco:CharacterString>WWW:LINK-1.0-http--downloaddata</gco:CharacterString>
                      </cit:protocol>
                      <cit:name>
-                        <gcx:MimeFileType type="application/octet-stream"/>
-                     </cit:name>
-                     <cit:description>
                         <gco:CharacterString>AATAMS (Australian Animal Tracking and Monitoring System) Data Access URL. This page is a point of access for all publicly accessible data collected by the IMOS AATAMS Facility as well as the data entry and upload point for facility members.</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/597351b5-7bce-44ac-aa04-5e59e5abb5e2.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/597351b5-7bce-44ac-aa04-5e59e5abb5e2.xml
@@ -125,12 +125,9 @@
                            <cit:protocol>
                               <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                            </cit:protocol>
-                           <cit:name gco:nilReason="missing">
-                              <gco:CharacterString/>
-                           </cit:name>
-                           <cit:description>
+                           <cit:name>
                               <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                           </cit:description>
+                           </cit:name>
                         </cit:CI_OnlineResource>
                      </cit:onlineResource>
                   </cit:CI_Contact>
@@ -263,12 +260,9 @@
                                        <cit:protocol>
                                           <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                        </cit:protocol>
-                                       <cit:name gco:nilReason="missing">
-                                          <gco:CharacterString/>
-                                       </cit:name>
-                                       <cit:description>
+                                       <cit:name>
                                           <gco:CharacterString>CSIRO Oceans &amp; Atmosphere website</gco:CharacterString>
-                                       </cit:description>
+                                       </cit:name>
                                     </cit:CI_OnlineResource>
                                  </cit:onlineResource>
                               </cit:CI_Contact>
@@ -411,12 +405,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>CSIRO Oceans &amp; Atmosphere website</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
             </cit:CI_Citation>
@@ -607,12 +598,9 @@
                                  <cit:protocol>
                                     <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                  </cit:protocol>
-                                 <cit:name gco:nilReason="missing">
-                                    <gco:CharacterString/>
-                                 </cit:name>
-                                 <cit:description>
+                                 <cit:name>
                                     <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                                 </cit:description>
+                                 </cit:name>
                               </cit:CI_OnlineResource>
                            </cit:onlineResource>
                         </cit:CI_Contact>
@@ -1161,7 +1149,7 @@
                         <gco:Real>-2</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e462">
+                        <gml:BaseUnit gml:id="d20e462">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPAA</gml:identifier>
                            <gml:name>Degrees Celsius</gml:name>
                            <gml:unitsSystem/>
@@ -1185,7 +1173,7 @@
                         <gco:Real>0</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e512">
+                        <gml:BaseUnit gml:id="d20e512">
                            <gml:identifier codeSpace="unknown">http://vocab.aodn.org.au/def/unitsofmeasure/entity/481</gml:identifier>
                            <gml:name>Practical Salinity Unit</gml:name>
                            <gml:unitsSystem/>
@@ -1203,7 +1191,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e562">
+                        <gml:BaseUnit gml:id="d20e562">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UVAA</gml:identifier>
                            <gml:name>Metres per second</gml:name>
                            <gml:unitsSystem/>
@@ -1221,7 +1209,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e608">
+                        <gml:BaseUnit gml:id="d20e608">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UAAA</gml:identifier>
                            <gml:name>Degrees</gml:name>
                            <gml:unitsSystem/>
@@ -1239,7 +1227,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e654">
+                        <gml:BaseUnit gml:id="d20e654">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/HPAX</gml:identifier>
                            <gml:name>Hectopascals</gml:name>
                            <gml:unitsSystem/>
@@ -1257,7 +1245,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e700">
+                        <gml:BaseUnit gml:id="d20e700">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UATM</gml:identifier>
                            <gml:name>Microatmospheres</gml:name>
                            <gml:unitsSystem/>
@@ -1275,7 +1263,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e746">
+                        <gml:BaseUnit gml:id="d20e746">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UATM</gml:identifier>
                            <gml:name>Microatmospheres</gml:name>
                            <gml:unitsSystem/>
@@ -1293,7 +1281,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e792">
+                        <gml:BaseUnit gml:id="d20e792">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UATM</gml:identifier>
                            <gml:name>Microatmospheres</gml:name>
                            <gml:unitsSystem/>
@@ -1314,7 +1302,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e838">
+                        <gml:BaseUnit gml:id="d20e838">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPPM</gml:identifier>
                            <gml:name>Parts per million</gml:name>
                            <gml:unitsSystem/>
@@ -1332,7 +1320,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e886">
+                        <gml:BaseUnit gml:id="d20e886">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPPM</gml:identifier>
                            <gml:name>Parts per million</gml:name>
                            <gml:unitsSystem/>
@@ -1372,12 +1360,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Link to biogeochemical sensors page on IMOS website</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                      <cit:function>
                         <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
                                                    codeListValue="information"/>
@@ -1392,12 +1377,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>View and download data though the AODN Portal</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1408,12 +1390,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>NetCDF files via THREDDS catalog</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1456,12 +1435,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>OGC WFS help documentation</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1488,12 +1464,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>ncUrlList help documentation</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
             </mrd:MD_DigitalTransferOptions>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/63db5801-cc19-40ef-83b3-85ccba884cf7.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/63db5801-cc19-40ef-83b3-85ccba884cf7.xml
@@ -126,12 +126,9 @@
                            <cit:protocol>
                               <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                            </cit:protocol>
-                           <cit:name gco:nilReason="missing">
-                              <gco:CharacterString/>
-                           </cit:name>
-                           <cit:description>
+                           <cit:name>
                               <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                           </cit:description>
+                           </cit:name>
                         </cit:CI_OnlineResource>
                      </cit:onlineResource>
                   </cit:CI_Contact>
@@ -278,12 +275,9 @@
                                        <cit:protocol>
                                           <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                        </cit:protocol>
-                                       <cit:name gco:nilReason="missing">
-                                          <gco:CharacterString/>
-                                       </cit:name>
-                                       <cit:description>
+                                       <cit:name>
                                           <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                                       </cit:description>
+                                       </cit:name>
                                     </cit:CI_OnlineResource>
                                  </cit:onlineResource>
                                  <cit:hoursOfService>
@@ -306,12 +300,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
             </cit:CI_Citation>
@@ -404,12 +395,9 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                                  <cit:protocol>
                                     <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                  </cit:protocol>
-                                 <cit:name gco:nilReason="missing">
-                                    <gco:CharacterString/>
-                                 </cit:name>
-                                 <cit:description>
+                                 <cit:name>
                                     <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                                 </cit:description>
+                                 </cit:name>
                               </cit:CI_OnlineResource>
                            </cit:onlineResource>
                         </cit:CI_Contact>
@@ -1247,7 +1235,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         <gco:Real>-2</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e545">
+                        <gml:BaseUnit gml:id="d20e545">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPAA</gml:identifier>
                            <gml:name>Degrees Celsius</gml:name>
                            <gml:unitsSystem/>
@@ -1271,7 +1259,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         <gco:Real>0</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e595">
+                        <gml:BaseUnit gml:id="d20e595">
                            <gml:identifier codeSpace="unknown">http://vocab.aodn.org.au/def/unitsofmeasure/entity/481</gml:identifier>
                            <gml:name>Practical Salinity Unit</gml:name>
                            <gml:unitsSystem/>
@@ -1289,7 +1277,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e645">
+                        <gml:BaseUnit gml:id="d20e645">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UVAA</gml:identifier>
                            <gml:name>Metres per second</gml:name>
                            <gml:unitsSystem/>
@@ -1307,7 +1295,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e691">
+                        <gml:BaseUnit gml:id="d20e691">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UAAA</gml:identifier>
                            <gml:name>Degrees</gml:name>
                            <gml:unitsSystem/>
@@ -1325,7 +1313,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e737">
+                        <gml:BaseUnit gml:id="d20e737">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/HPAX</gml:identifier>
                            <gml:name>Hectopascals</gml:name>
                            <gml:unitsSystem/>
@@ -1343,7 +1331,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e783">
+                        <gml:BaseUnit gml:id="d20e783">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UATM</gml:identifier>
                            <gml:name>Microatmospheres</gml:name>
                            <gml:unitsSystem/>
@@ -1361,7 +1349,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e829">
+                        <gml:BaseUnit gml:id="d20e829">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UATM</gml:identifier>
                            <gml:name>Microatmospheres</gml:name>
                            <gml:unitsSystem/>
@@ -1379,7 +1367,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e875">
+                        <gml:BaseUnit gml:id="d20e875">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UATM</gml:identifier>
                            <gml:name>Microatmospheres</gml:name>
                            <gml:unitsSystem/>
@@ -1400,7 +1388,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e921">
+                        <gml:BaseUnit gml:id="d20e921">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPPM</gml:identifier>
                            <gml:name>Parts per million</gml:name>
                            <gml:unitsSystem/>
@@ -1418,7 +1406,7 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e969">
+                        <gml:BaseUnit gml:id="d20e969">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPPM</gml:identifier>
                            <gml:name>Parts per million</gml:name>
                            <gml:unitsSystem/>
@@ -1458,12 +1446,9 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Link to biogeochemical sensors page on IMOS website</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                      <cit:function>
                         <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
                                                    codeListValue="information"/>
@@ -1478,12 +1463,9 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Marine National Facility Website: Information about RV Southern Surveyor and RV Investigator</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1510,12 +1492,9 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>NetCDF files via THREDDS catalog</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1526,12 +1505,9 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>View and download data though the AODN Portal</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1574,12 +1550,9 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>OGC WFS help documentation</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1606,12 +1579,9 @@ The RV Aurora Australis provides data on surface ocean CO2 for the Southern Ocea
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>ncUrlList help documentation</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
             </mrd:MD_DigitalTransferOptions>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -272,9 +272,9 @@
                                        <cit:protocol>
                                           <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                        </cit:protocol>
-                                       <cit:description>
+                                       <cit:name>
                                           <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                                       </cit:description>
+                                       </cit:name>
                                     </cit:CI_OnlineResource>
                                  </cit:onlineResource>
                               </cit:CI_Contact>
@@ -304,9 +304,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
             </cit:CI_Citation>
@@ -1167,7 +1167,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e483">
+                        <gml:BaseUnit gml:id="d20e483">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPAA</gml:identifier>
                            <gml:name>Degrees Celsius</gml:name>
                            <gml:unitsSystem/>
@@ -1185,7 +1185,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e529">
+                        <gml:BaseUnit gml:id="d20e529">
                            <gml:identifier codeSpace="unknown">http://vocab.aodn.org.au/def/unitsofmeasure/entity/481</gml:identifier>
                            <gml:name>Practical Salinity Unit</gml:name>
                            <gml:unitsSystem/>
@@ -1203,7 +1203,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e575">
+                        <gml:BaseUnit gml:id="d20e575">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/USTU</gml:identifier>
                            <gml:name>Nephelometric Turbidity Units</gml:name>
                            <gml:unitsSystem/>
@@ -1221,7 +1221,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e621">
+                        <gml:BaseUnit gml:id="d20e621">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UGPL</gml:identifier>
                            <gml:name>Micrograms per litre</gml:name>
                            <gml:unitsSystem/>
@@ -1361,12 +1361,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>IMOS: Sensors on Tropical Research Vessels</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1377,12 +1374,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>NetCDF files via THREDDS catalog</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1393,12 +1387,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>View and download data though the AODN Portal</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
                <mrd:onLine>
@@ -1441,12 +1432,9 @@
                      <cit:protocol>
                         <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                      </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description>
+                     <cit:name>
                         <gco:CharacterString>OGC WFS help documentation</gco:CharacterString>
-                     </cit:description>
+                     </cit:name>
                   </cit:CI_OnlineResource>
                </mrd:onLine>
             </mrd:MD_DigitalTransferOptions>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/expected/7d3a2249-6f9a-4dc9-8bbb-354009f5b254.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/expected/7d3a2249-6f9a-4dc9-8bbb-354009f5b254.xml
@@ -100,7 +100,7 @@
                         <gco:Real>-1000</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e18">
+                        <gml:BaseUnit gml:id="d20e18">
                            <gml:identifier codeSpace="unknown"/>
                            <gml:name>Metres</gml:name>
                            <gml:unitsSystem/>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -238,7 +238,7 @@
                         <gco:Real>271</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e19">
+                        <gml:BaseUnit gml:id="d20e19">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPKA</gml:identifier>
                            <gml:name>Degrees Kelvin</gml:name>
                            <gml:unitsSystem/>
@@ -269,7 +269,7 @@
                         <gco:Real>-3</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e119">
+                        <gml:BaseUnit gml:id="d20e119">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPAA</gml:identifier>
                            <gml:name>Degrees Celsius</gml:name>
                            <gml:unitsSystem/>
@@ -296,7 +296,7 @@
                         <gco:Real>-1000</gco:Real>
                      </mrc:minValue>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e178">
+                        <gml:BaseUnit gml:id="d20e178">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UPAA</gml:identifier>
                            <gml:name>Degrees Celsius</gml:name>
                            <gml:unitsSystem/>
@@ -317,7 +317,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e354">
+                        <gml:BaseUnit gml:id="d20e354">
                            <gml:identifier codeSpace="unknown">http://vocab.nerc.ac.uk/collection/P06/current/UAAA</gml:identifier>
                            <gml:name>Degrees</gml:name>
                            <gml:unitsSystem/>
@@ -335,7 +335,7 @@
                         </mcc:MD_Identifier>
                      </mrc:name>
                      <mrc:units>
-                        <gml:BaseUnit gml:id="d19e391">
+                        <gml:BaseUnit gml:id="d20e391">
                            <gml:identifier codeSpace="unknown"/>
                            <gml:name/>
                            <gml:unitsSystem/>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/metadataContact/expected/b299cdcd-3dee-48aa-abdd-e0fcdbb9cadc.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/metadataContact/expected/b299cdcd-3dee-48aa-abdd-e0fcdbb9cadc.xml
@@ -126,12 +126,9 @@
                            <cit:protocol>
                               <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                            </cit:protocol>
-                           <cit:name gco:nilReason="missing">
-                              <gco:CharacterString/>
-                           </cit:name>
-                           <cit:description>
+                           <cit:name>
                               <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                           </cit:description>
+                           </cit:name>
                         </cit:CI_OnlineResource>
                      </cit:onlineResource>
                   </cit:CI_Contact>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/onlineResource/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/onlineResource/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -51,9 +51,6 @@
                <cit:title>
                   <gco:CharacterString>Sensors on Tropical Research Vessels: Enhanced Measurements from Ships of Opportunity (SOOP)</gco:CharacterString>
                </cit:title>
-               <cit:alternateTitle>
-                  <gco:CharacterString>Ship underway data in tropical waters</gco:CharacterString>
-               </cit:alternateTitle>
                <cit:date>
                   <cit:CI_Date>
                      <cit:date>
@@ -65,16 +62,6 @@
                      </cit:dateType>
                   </cit:CI_Date>
                </cit:date>
-               <cit:editionDate>
-                  <gco:DateTime>2014-01-08T00:00:00</gco:DateTime>
-               </cit:editionDate>
-               <cit:identifier>
-                  <mcc:MD_Identifier>
-                     <mcc:code>
-                        <gco:CharacterString>DOI: 10.26198/5e156a63a8f75</gco:CharacterString>
-                     </mcc:code>
-                  </mcc:MD_Identifier>
-               </cit:identifier>
                <cit:citedResponsibleParty>
                   <cit:CI_Responsibility>
                      <cit:role>
@@ -82,56 +69,12 @@
                                          codeListValue="resourceProvider"/>
                      </cit:role>
                      <cit:party>
-                        <cit:CI_Organisation>
-                           <cit:name>
-                              <gco:CharacterString>Integrated Marine Observing System (IMOS)</gco:CharacterString>
+                        <cit:CI_Individual>
+                           <cit:name gco:nilReason="missing">
+                              <gco:CharacterString/>
                            </cit:name>
                            <cit:contactInfo>
                               <cit:CI_Contact>
-                                 <cit:phone>
-                                    <cit:CI_Telephone>
-                                       <cit:number>
-                                          <gco:CharacterString>61 3 6226 7549</gco:CharacterString>
-                                       </cit:number>
-                                       <cit:numberType>
-                                          <cit:CI_TelephoneTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode"
-                                                                    codeListValue="voice"/>
-                                       </cit:numberType>
-                                    </cit:CI_Telephone>
-                                 </cit:phone>
-                                 <cit:phone>
-                                    <cit:CI_Telephone>
-                                       <cit:number>
-                                          <gco:CharacterString>+61 3 6226 2107</gco:CharacterString>
-                                       </cit:number>
-                                       <cit:numberType>
-                                          <cit:CI_TelephoneTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode"
-                                                                    codeListValue="facsimile"/>
-                                       </cit:numberType>
-                                    </cit:CI_Telephone>
-                                 </cit:phone>
-                                 <cit:address>
-                                    <cit:CI_Address>
-                                       <cit:deliveryPoint>
-                                          <gco:CharacterString>Private Bag 110</gco:CharacterString>
-                                       </cit:deliveryPoint>
-                                       <cit:city>
-                                          <gco:CharacterString>Hobart</gco:CharacterString>
-                                       </cit:city>
-                                       <cit:administrativeArea>
-                                          <gco:CharacterString>Tasmania</gco:CharacterString>
-                                       </cit:administrativeArea>
-                                       <cit:postalCode>
-                                          <gco:CharacterString>7001</gco:CharacterString>
-                                       </cit:postalCode>
-                                       <cit:country>
-                                          <gco:CharacterString>Australia</gco:CharacterString>
-                                       </cit:country>
-                                       <cit:electronicMailAddress>
-                                          <gco:CharacterString>imos@imos.org.au</gco:CharacterString>
-                                       </cit:electronicMailAddress>
-                                    </cit:CI_Address>
-                                 </cit:address>
                                  <cit:onlineResource>
                                     <cit:CI_OnlineResource>
                                        <cit:linkage>
@@ -145,35 +88,12 @@
                                        </cit:name>
                                     </cit:CI_OnlineResource>
                                  </cit:onlineResource>
-                                 <cit:hoursOfService>
-                                    <gco:CharacterString>9am to 5pm UTC+10: Monday to Friday</gco:CharacterString>
-                                 </cit:hoursOfService>
                               </cit:CI_Contact>
                            </cit:contactInfo>
-                           <cit:individual>
-                              <cit:CI_Individual>
-                                 <cit:name gco:nilReason="missing">
-                                    <gco:CharacterString/>
-                                 </cit:name>
-                                 <cit:positionName gco:nilReason="missing">
-                                    <gco:CharacterString/>
-                                 </cit:positionName>
-                              </cit:CI_Individual>
-                           </cit:individual>
-                        </cit:CI_Organisation>
+                        </cit:CI_Individual>
                      </cit:party>
                   </cit:CI_Responsibility>
                </cit:citedResponsibleParty>
-               <cit:series>
-                  <cit:CI_Series>
-                     <cit:name>
-                        <gco:CharacterString>CAASM Metadata</gco:CharacterString>
-                     </cit:name>
-                  </cit:CI_Series>
-               </cit:series>
-               <cit:otherCitationDetails>
-                  <gco:CharacterString>The citation in a list of references is: 'IMOS [year-of-data-downloaded], [Title], [data-access-url], accessed [date-of-access]'</gco:CharacterString>
-               </cit:otherCitationDetails>
                <cit:onlineResource>
                   <cit:CI_OnlineResource>
                      <cit:linkage>
@@ -190,6 +110,38 @@
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract gco:nilReason="missing"/>
+         <mri:pointOfContact>
+            <cit:CI_Responsibility>
+               <cit:role>
+                  <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode"
+                                   codeListValue="pointOfContact"/>
+               </cit:role>
+               <cit:party>
+                  <cit:CI_Individual>
+                     <cit:name>
+                        <gco:CharacterString>Benthuysen, Jessica, Dr</gco:CharacterString>
+                     </cit:name>
+                     <cit:contactInfo>
+                        <cit:CI_Contact>
+                           <cit:onlineResource>
+                              <cit:CI_OnlineResource>
+                                 <cit:linkage>
+                                    <gco:CharacterString>http://www.aims.gov.au</gco:CharacterString>
+                                 </cit:linkage>
+                                 <cit:protocol>
+                                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                                 </cit:protocol>
+                              </cit:CI_OnlineResource>
+                           </cit:onlineResource>
+                           <cit:hoursOfService>
+                              <gco:CharacterString>0800 to 1640 UTC+10: Monday to Friday</gco:CharacterString>
+                           </cit:hoursOfService>
+                        </cit:CI_Contact>
+                     </cit:contactInfo>
+                  </cit:CI_Individual>
+               </cit:party>
+            </cit:CI_Responsibility>
+         </mri:pointOfContact>
          <mri:defaultLocale>
             <lan:PT_Locale>
                <lan:language>
@@ -200,4 +152,57 @@
          </mri:defaultLocale>
       </mri:MD_DataIdentification>
    </mdb:identificationInfo>
+   <mdb:distributionInfo>
+      <mrd:MD_Distribution>
+         <mrd:distributionFormat>
+            <mrd:MD_Format>
+               <mrd:formatSpecificationCitation>
+                  <cit:CI_Citation>
+                     <cit:title>
+                        <gco:CharacterString>Web Download</gco:CharacterString>
+                     </cit:title>
+                     <cit:alternateTitle/>
+                     <cit:date gco:nilReason="unknown"/>
+                     <cit:edition>
+                        <gco:CharacterString>HTTP:1.1</gco:CharacterString>
+                     </cit:edition>
+                  </cit:CI_Citation>
+               </mrd:formatSpecificationCitation>
+            </mrd:MD_Format>
+         </mrd:distributionFormat>
+         <mrd:transferOptions>
+            <mrd:MD_DigitalTransferOptions>
+               <mrd:onLine>
+                  <cit:CI_OnlineResource>
+                     <cit:linkage>
+                        <gco:CharacterString>http://data.aims.gov.au/extpubs/do/viewPub.do?articleId=8541</gco:CharacterString>
+                     </cit:linkage>
+                     <cit:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--related</gco:CharacterString>
+                     </cit:protocol>
+                     <cit:name>
+                        <gco:CharacterString>Enhancing ship of opportunity sea surface temperature observations in the Australian region</gco:CharacterString>
+                     </cit:name>
+                     <cit:description>
+                        <gco:CharacterString>Beggs H, Verein R, Kippo H, Underwood M, Barton IJ, Steinberg CR, Schulz E, Hibbins R, Thomas A and Ball G (2009) Enhancing ship of opportunity sea surface temperature observations in the Australian region. unformatted - In: Proceedings of the GHRSST Data Users Symposium, Santa Rosa, USA, 28-29 May 2009.</gco:CharacterString>
+                     </cit:description>
+                  </cit:CI_OnlineResource>
+               </mrd:onLine>
+               <mrd:onLine>
+                  <cit:CI_OnlineResource>
+                     <cit:linkage>
+                        <gco:CharacterString>http://imos.org.au/tropicalresearchvessels.html</gco:CharacterString>
+                     </cit:linkage>
+                     <cit:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                     </cit:protocol>
+                     <cit:name>
+                        <gco:CharacterString>IMOS: Sensors on Tropical Research Vessels</gco:CharacterString>
+                     </cit:name>
+                  </cit:CI_OnlineResource>
+               </mrd:onLine>
+            </mrd:MD_DigitalTransferOptions>
+         </mrd:transferOptions>
+      </mrd:MD_Distribution>
+   </mdb:distributionInfo>
 </mdb:MD_Metadata>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/onlineResource/export/8af21108-c535-43bf-8dab-c1f45a26088c/metadata/metadata.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/onlineResource/export/8af21108-c535-43bf-8dab-c1f45a26088c/metadata/metadata.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mcp:MD_Metadata xmlns:mcp="http://schemas.aodn.org.au/mcp-2.0" xmlns:dwc="http://rs.tdwg.org/dwc/terms/" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gml="http://www.opengis.net/gml" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://schemas.aodn.org.au/mcp-2.0 http://schemas.aodn.org.au/mcp-2.0/schema.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd http://rs.tdwg.org/dwc/terms/ http://schemas.aodn.org.au/mcp-2.0/mcpDwcTerms.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>8af21108-c535-43bf-8dab-c1f45a26088c</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:contact gco:nilReason="missing">
+  </gmd:contact>
+  <gmd:dateStamp gco:nilReason="missing">
+  </gmd:dateStamp>
+  <gmd:identificationInfo>
+    <mcp:MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Sensors on Tropical Research Vessels: Enhanced Measurements from Ships of Opportunity (SOOP)</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:DateTime>2009-04-21T00:00:00</gco:DateTime>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:citedResponsibleParty>
+            <gmd:CI_ResponsibleParty>
+              <gmd:individualName gco:nilReason="missing">
+                <gco:CharacterString/>
+              </gmd:individualName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage>
+                        <gmd:URL>http://www.imos.org.au</gmd:URL>
+                      </gmd:linkage>
+                      <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                      </gmd:protocol>
+                      <gmd:description>
+                        <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
+                      </gmd:description>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="resourceProvider">resourceProvider</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract gco:nilReason="missing"/>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:individualName>
+            <gco:CharacterString>Benthuysen, Jessica, Dr</gco:CharacterString>
+          </gmd:individualName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>http://www.aims.gov.au</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+              <gmd:hoursOfService>
+                <gco:CharacterString>0800 to 1640 UTC+10: Monday to Friday</gco:CharacterString>
+              </gmd:hoursOfService>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:language>
+        <gco:CharacterString xmlns:srv="http://www.isotc211.org/2005/srv">eng</gco:CharacterString>
+      </gmd:language>
+    </mcp:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat>
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>Web Download</gco:CharacterString>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>HTTP:1.1</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>http://data.aims.gov.au/extpubs/do/viewPub.do?articleId=8541</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--related</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>Enhancing ship of opportunity sea surface temperature observations in the Australian region</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Beggs H, Verein R, Kippo H, Underwood M, Barton IJ, Steinberg CR, Schulz E, Hibbins R, Thomas A and Ball G (2009) Enhancing ship of opportunity sea surface temperature observations in the Australian region. unformatted - In: Proceedings of the GHRSST Data Users Symposium, Santa Rosa, USA, 28-29 May 2009.</gco:CharacterString>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>http://imos.org.au/tropicalresearchvessels.html</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name gco:nilReason="missing">
+                <gco:CharacterString/>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>IMOS: Sensors on Tropical Research Vessels</gco:CharacterString>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+</mcp:MD_Metadata>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/pointOfContact/expected/077f2cce-9817-42d2-b3ef-a00d29eb0ed3.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/pointOfContact/expected/077f2cce-9817-42d2-b3ef-a00d29eb0ed3.xml
@@ -208,12 +208,9 @@
                                  <cit:protocol>
                                     <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                                  </cit:protocol>
-                                 <cit:name gco:nilReason="missing">
-                                    <gco:CharacterString/>
-                                 </cit:name>
-                                 <cit:description>
+                                 <cit:name>
                                     <gco:CharacterString>Website of the Australian Ocean Data Network (AODN)</gco:CharacterString>
-                                 </cit:description>
+                                 </cit:name>
                                  <cit:function>
                                     <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
                                                                codeListValue="information"/>


### PR DESCRIPTION
Works better with display of links in GN3 and makes sense anyway for IMOS records.

Fixes issues with display of websites/links etc.
