### PR TITLE
Don't copy online resources in cited responsible parties

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
@@ -58,14 +58,6 @@
     <xsl:template match="gmd:CI_Citation" mode="from19139to19115-3">
         <xsl:element name="cit:CI_Citation">
             <xsl:apply-templates mode="from19139to19115-3"/>
-            <!-- Special attention is required for CI_ResponsibleParties that are included in the 
-                CI_Citation only for a URL. These are currently identified as those 
-                with no name elements (individualName, organisationName, or positionName)
-            -->
-            <xsl:for-each
-                select=".//gmd:CI_ResponsibleParty[count(gmd:individualName/gco:CharacterString) + count(gmd:organisationName/gco:CharacterString) + count(gmd:positionName/gco:CharacterString) = 0]">
-                <xsl:call-template name="CI_ResponsiblePartyToOnlineResource"/>
-            </xsl:for-each>
         </xsl:element>
     </xsl:template>
 

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/citation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/citation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -174,19 +174,6 @@
                <cit:otherCitationDetails>
                   <gco:CharacterString>The citation in a list of references is: 'IMOS [year-of-data-downloaded], [Title], [data-access-url], accessed [date-of-access]'</gco:CharacterString>
                </cit:otherCitationDetails>
-               <cit:onlineResource>
-                  <cit:CI_OnlineResource>
-                     <cit:linkage>
-                        <gco:CharacterString>http://www.imos.org.au</gco:CharacterString>
-                     </cit:linkage>
-                     <cit:protocol>
-                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                     </cit:protocol>
-                     <cit:name>
-                        <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                     </cit:name>
-                  </cit:CI_OnlineResource>
-               </cit:onlineResource>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract gco:nilReason="missing"/>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/citation/expected/d431c584-8d1e-429b-ad6d-0e03be3b95b2.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/citation/expected/d431c584-8d1e-429b-ad6d-0e03be3b95b2.xml
@@ -230,22 +230,6 @@
                      </cit:name>
                   </cit:CI_Series>
                </cit:series>
-               <cit:onlineResource>
-                  <cit:CI_OnlineResource>
-                     <cit:linkage gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:linkage>
-                     <cit:protocol gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:protocol>
-                     <cit:name gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:name>
-                     <cit:description gco:nilReason="missing">
-                        <gco:CharacterString/>
-                     </cit:description>
-                  </cit:CI_OnlineResource>
-               </cit:onlineResource>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract gco:nilReason="missing"/>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/4a97bd11-e821-4682-8b20-cb69201f3223.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/4a97bd11-e821-4682-8b20-cb69201f3223.xml
@@ -300,19 +300,6 @@
                <cit:otherCitationDetails>
                   <gco:CharacterString>The citation in a list of references is: "IMOS. [year-of-data-download], [Title], [data-access-URL], accessed [date-of-access]".</gco:CharacterString>
                </cit:otherCitationDetails>
-               <cit:onlineResource>
-                  <cit:CI_OnlineResource>
-                     <cit:linkage>
-                        <gco:CharacterString>www.imos.org.au/html</gco:CharacterString>
-                     </cit:linkage>
-                     <cit:protocol>
-                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                     </cit:protocol>
-                     <cit:name>
-                        <gco:CharacterString>Website for the Integrated Marine Observing System</gco:CharacterString>
-                     </cit:name>
-                  </cit:CI_OnlineResource>
-               </cit:onlineResource>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/597351b5-7bce-44ac-aa04-5e59e5abb5e2.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/597351b5-7bce-44ac-aa04-5e59e5abb5e2.xml
@@ -397,19 +397,6 @@
                      </cit:party>
                   </cit:CI_Responsibility>
                </cit:citedResponsibleParty>
-               <cit:onlineResource>
-                  <cit:CI_OnlineResource>
-                     <cit:linkage>
-                        <gco:CharacterString>http://www.csiro.au/en/Research/OandA</gco:CharacterString>
-                     </cit:linkage>
-                     <cit:protocol>
-                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                     </cit:protocol>
-                     <cit:name>
-                        <gco:CharacterString>CSIRO Oceans &amp; Atmosphere website</gco:CharacterString>
-                     </cit:name>
-                  </cit:CI_OnlineResource>
-               </cit:onlineResource>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/63db5801-cc19-40ef-83b3-85ccba884cf7.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/63db5801-cc19-40ef-83b3-85ccba884cf7.xml
@@ -292,19 +292,6 @@
                <cit:otherCitationDetails>
                   <gco:CharacterString>The citation in a list of references is: "IMOS [year-of-data-downloaded], [Title], [data-access-url], accessed [date-of-access]".</gco:CharacterString>
                </cit:otherCitationDetails>
-               <cit:onlineResource>
-                  <cit:CI_OnlineResource>
-                     <cit:linkage>
-                        <gco:CharacterString>http://www.imos.org.au/html</gco:CharacterString>
-                     </cit:linkage>
-                     <cit:protocol>
-                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                     </cit:protocol>
-                     <cit:name>
-                        <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                     </cit:name>
-                  </cit:CI_OnlineResource>
-               </cit:onlineResource>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/codelistlocation/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -296,19 +296,6 @@
                <cit:otherCitationDetails>
                   <gco:CharacterString>The citation in a list of references is: 'IMOS [year-of-data-downloaded], [Title], [data-access-url], accessed [date-of-access]'</gco:CharacterString>
                </cit:otherCitationDetails>
-               <cit:onlineResource>
-                  <cit:CI_OnlineResource>
-                     <cit:linkage>
-                        <gco:CharacterString>http://www.imos.org.au</gco:CharacterString>
-                     </cit:linkage>
-                     <cit:protocol>
-                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                     </cit:protocol>
-                     <cit:name>
-                        <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                     </cit:name>
-                  </cit:CI_OnlineResource>
-               </cit:onlineResource>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract>
@@ -600,16 +587,6 @@
                            </cit:party>
                         </cit:CI_Responsibility>
                      </cit:citedResponsibleParty>
-                     <cit:onlineResource>
-                        <cit:CI_OnlineResource>
-                           <cit:linkage>
-                              <gco:CharacterString>http://gcmd.nasa.gov/index.html</gco:CharacterString>
-                           </cit:linkage>
-                           <cit:protocol>
-                              <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                           </cit:protocol>
-                        </cit:CI_OnlineResource>
-                     </cit:onlineResource>
                   </cit:CI_Citation>
                </mri:thesaurusName>
             </mri:MD_Keywords>
@@ -674,16 +651,6 @@
                            </cit:party>
                         </cit:CI_Responsibility>
                      </cit:citedResponsibleParty>
-                     <cit:onlineResource>
-                        <cit:CI_OnlineResource>
-                           <cit:linkage>
-                              <gco:CharacterString>http://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1297.01998?OpenDocument</gco:CharacterString>
-                           </cit:linkage>
-                           <cit:protocol>
-                              <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                           </cit:protocol>
-                        </cit:CI_OnlineResource>
-                     </cit:onlineResource>
                   </cit:CI_Citation>
                </mri:thesaurusName>
             </mri:MD_Keywords>
@@ -771,16 +738,6 @@
                            </cit:party>
                         </cit:CI_Responsibility>
                      </cit:citedResponsibleParty>
-                     <cit:onlineResource>
-                        <cit:CI_OnlineResource>
-                           <cit:linkage>
-                              <gco:CharacterString>http://www.aodc.gov.au/</gco:CharacterString>
-                           </cit:linkage>
-                           <cit:protocol>
-                              <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                           </cit:protocol>
-                        </cit:CI_OnlineResource>
-                     </cit:onlineResource>
                   </cit:CI_Citation>
                </mri:thesaurusName>
             </mri:MD_Keywords>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/descriptiveKeywords/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/descriptiveKeywords/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -124,16 +124,6 @@
                            </cit:party>
                         </cit:CI_Responsibility>
                      </cit:citedResponsibleParty>
-                     <cit:onlineResource>
-                        <cit:CI_OnlineResource>
-                           <cit:linkage>
-                              <gco:CharacterString>http://gcmd.nasa.gov/index.html</gco:CharacterString>
-                           </cit:linkage>
-                           <cit:protocol>
-                              <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                           </cit:protocol>
-                        </cit:CI_OnlineResource>
-                     </cit:onlineResource>
                   </cit:CI_Citation>
                </mri:thesaurusName>
             </mri:MD_Keywords>
@@ -198,16 +188,6 @@
                            </cit:party>
                         </cit:CI_Responsibility>
                      </cit:citedResponsibleParty>
-                     <cit:onlineResource>
-                        <cit:CI_OnlineResource>
-                           <cit:linkage>
-                              <gco:CharacterString>http://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1297.01998?OpenDocument</gco:CharacterString>
-                           </cit:linkage>
-                           <cit:protocol>
-                              <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                           </cit:protocol>
-                        </cit:CI_OnlineResource>
-                     </cit:onlineResource>
                   </cit:CI_Citation>
                </mri:thesaurusName>
             </mri:MD_Keywords>
@@ -295,16 +275,6 @@
                            </cit:party>
                         </cit:CI_Responsibility>
                      </cit:citedResponsibleParty>
-                     <cit:onlineResource>
-                        <cit:CI_OnlineResource>
-                           <cit:linkage>
-                              <gco:CharacterString>http://www.aodc.gov.au/</gco:CharacterString>
-                           </cit:linkage>
-                           <cit:protocol>
-                              <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                           </cit:protocol>
-                        </cit:CI_OnlineResource>
-                     </cit:onlineResource>
                   </cit:CI_Citation>
                </mri:thesaurusName>
             </mri:MD_Keywords>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/onlineResource/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/onlineResource/expected/8af21108-c535-43bf-8dab-c1f45a26088c.xml
@@ -94,19 +94,6 @@
                      </cit:party>
                   </cit:CI_Responsibility>
                </cit:citedResponsibleParty>
-               <cit:onlineResource>
-                  <cit:CI_OnlineResource>
-                     <cit:linkage>
-                        <gco:CharacterString>http://www.imos.org.au</gco:CharacterString>
-                     </cit:linkage>
-                     <cit:protocol>
-                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
-                     </cit:protocol>
-                     <cit:name>
-                        <gco:CharacterString>Website of the Integrated Marine Observing System (IMOS)</gco:CharacterString>
-                     </cit:name>
-                  </cit:CI_OnlineResource>
-               </cit:onlineResource>
             </cit:CI_Citation>
          </mri:citation>
          <mri:abstract gco:nilReason="missing"/>


### PR DESCRIPTION
The current transform copies these online resources to the ci_citation element.  This looks like an organisation specific business rule that didn't work when this code was taken.  We don't want it anyway - its not required.