### PR TITLE
Addresses aodn/backlog#2195 - fix IMAS transformation issues

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
@@ -57,7 +57,34 @@
     </xd:doc>
     <xsl:template match="gmd:CI_Citation" mode="from19139to19115-3">
         <xsl:element name="cit:CI_Citation">
-            <xsl:apply-templates mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:title" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:alternateTitle" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:date" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:edition" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:editionDate" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:identifier" mode="from19139to19115-3"/>
+
+        <!-- Add any datasetUri as an identifier in the resource (dataIdentification) citation -->
+
+        <xsl:if test="../../..[name()='gmd:identificationInfo'] and /*/gmd:dataSetURI">
+          <cit:identifier>
+            <mcc:MD_Identifier>
+              <mcc:code>
+                <gco:CharacterString>
+                  <xsl:value-of select="/*/gmd:dataSetURI/gcoold:CharacterString"/>
+                </gco:CharacterString>
+              </mcc:code>
+            </mcc:MD_Identifier>
+          </cit:identifier>
+        </xsl:if>
+
+        <xsl:apply-templates select="gmd:citedResponsibleParty" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:presentationForm" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:series" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:otherCitationDetails" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:collectiveTitle" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:ISBN" mode="from19139to19115-3"/>
+        <xsl:apply-templates select="gmd:ISSN" mode="from19139to19115-3"/>
         </xsl:element>
     </xsl:template>
 

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_Citation.xsl
@@ -57,34 +57,43 @@
     </xd:doc>
     <xsl:template match="gmd:CI_Citation" mode="from19139to19115-3">
         <xsl:element name="cit:CI_Citation">
-        <xsl:apply-templates select="gmd:title" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:alternateTitle" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:date" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:edition" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:editionDate" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:identifier" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:title" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:alternateTitle" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:date" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:edition" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:editionDate" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:identifier" mode="from19139to19115-3"/>
 
-        <!-- Add any datasetUri as an identifier in the resource (dataIdentification) citation -->
+            <!-- Add any datasetUri as an identifier in the resource (dataIdentification) citation -->
 
-        <xsl:if test="../../..[name()='gmd:identificationInfo'] and /*/gmd:dataSetURI">
-          <cit:identifier>
-            <mcc:MD_Identifier>
-              <mcc:code>
-                <gco:CharacterString>
-                  <xsl:value-of select="/*/gmd:dataSetURI/gcoold:CharacterString"/>
-                </gco:CharacterString>
-              </mcc:code>
-            </mcc:MD_Identifier>
-          </cit:identifier>
-        </xsl:if>
+            <xsl:if test="../../..[name()='gmd:identificationInfo'] and /*/gmd:dataSetURI">
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code>
+                    <gco:CharacterString>
+                      <xsl:value-of select="/*/gmd:dataSetURI/gcoold:CharacterString"/>
+                    </gco:CharacterString>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </xsl:if>
 
-        <xsl:apply-templates select="gmd:citedResponsibleParty" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:presentationForm" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:series" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:otherCitationDetails" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:collectiveTitle" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:ISBN" mode="from19139to19115-3"/>
-        <xsl:apply-templates select="gmd:ISSN" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:citedResponsibleParty" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:presentationForm" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:series" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:otherCitationDetails" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:collectiveTitle" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:ISBN" mode="from19139to19115-3"/>
+            <xsl:apply-templates select="gmd:ISSN" mode="from19139to19115-3"/>
+
+            <!-- Special attention is required for CI_ResponsibleParties that are included in the
+                CI_Citation only for a URL. These are currently identified as those
+                with no name elements (individualName, organisationName, or positionName)
+            -->
+            <xsl:for-each
+                select=".//gmd:CI_ResponsibleParty[count(gmd:individualName/gcoold:CharacterString) + count(gmd:organisationName/gcoold:CharacterString) + count(gmd:positionName/gcoold:CharacterString) = 0]">
+                <xsl:call-template name="CI_ResponsiblePartyToOnlineResource"/>
+            </xsl:for-each>
         </xsl:element>
     </xsl:template>
 

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_ResponsibleParty.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/CI_ResponsibleParty.xsl
@@ -61,114 +61,94 @@
     </xd:doc>
 
     <xsl:template match="gmd:CI_ResponsibleParty" mode="from19139to19115-3">
-        <xsl:choose>
-            <xsl:when test="count(gmd:individualName/gcoold:CharacterString) + count(gmd:organisationName/gcoold:CharacterString) + count(gmd:positionName/gcoold:CharacterString) > 0">
-                <!--
-                CI_ResponsibleParties that include name elements (individualName, organisationName, or positionName) are translated to CI_Responsibilities.
-                CI_ResponsibleParties without name elements are assummed to be placeholders for CI_OnlineResources. They are transformed later in the process
-                using the CI_ResponsiblePartyToOnlineResource template
-                -->
-<!--              <xsl:choose>-->
-<!--                <xsl:when test="gmd:role/gmd:CI_RoleCode/@codeListValue = 'coInvestigator'">-->
-<!--                  <xsl:with-param name="codeListValue" select="collaborator"/>-->
-<!--                </xsl:when>-->
-<!--                <xsl:otherwise>-->
-<!--                  <xsl:with-param name="codeListValue" select="gmd:role/gmd:CI_RoleCode/@codeListValue"/>-->
-<!--                </xsl:otherwise>-->
-<!--              </xsl:choose>-->
-
-
-
-               <xsl:element name="cit:CI_Responsibility">
-                   <xsl:apply-templates select="./@*" mode="from19139to19115-3"/>
-                    <xsl:choose>
-                        <xsl:when test="./gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
-                          <xsl:choose>
-                            <xsl:when test="gmd:role/gmd:CI_RoleCode/@codeListValue = 'coInvestigator'">
-                              <xsl:call-template name="writeCodelistElement">
-                                <xsl:with-param name="elementName" select="'cit:role'"/>
-                                <xsl:with-param name="codeListName" select="'cit:CI_RoleCode'"/>
-                                <xsl:with-param name="codeListValue" select="'collaborator'"/>
-                              </xsl:call-template>
-                            </xsl:when>
-                            <xsl:when test="gmd:role/gmd:CI_RoleCode/@codeListValue = 'metadataContact'">
-                              <xsl:call-template name="writeCodelistElement">
-                                <xsl:with-param name="elementName" select="'cit:role'"/>
-                                <xsl:with-param name="codeListName" select="'cit:CI_RoleCode'"/>
-                                <xsl:with-param name="codeListValue" select="'pointOfContact'"/>
-                              </xsl:call-template>
-                            </xsl:when>
-                            <xsl:otherwise>
-                              <xsl:call-template name="writeCodelistElement">
-                                <xsl:with-param name="elementName" select="'cit:role'"/>
-                                <xsl:with-param name="codeListName" select="'cit:CI_RoleCode'"/>
-                                <xsl:with-param name="codeListValue" select="gmd:role/gmd:CI_RoleCode/@codeListValue"/>
-                              </xsl:call-template>
-                            </xsl:otherwise>
-                          </xsl:choose>
-                        </xsl:when>
-                        <xsl:when test="./gmd:role/@*">
-                            <cit:role>
-                                <xsl:apply-templates select="./gmd:role/@*" mode="from19139to19115-3"/>
-                            </cit:role>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <cit:role gco:nilReason="missing"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                    <cit:party>
-                        <xsl:choose>
-                            <xsl:when test="gmd:organisationName">
-                                <cit:CI_Organisation>
-                                    <xsl:call-template name="writeCharacterStringElement">
-                                        <xsl:with-param name="elementName" select="'cit:name'"/>
-                                        <xsl:with-param name="nodeWithStringToWrite" select="gmd:organisationName"/>
-                                    </xsl:call-template>
-                                    <!-- contactInformation comes before indivudual/position -->
-                                    <xsl:call-template name="writeContactInformation"/>
-                                    <xsl:if test="gmd:individualName | gmd:positionName">
-                                        <cit:individual>
-                                            <cit:CI_Individual>
-                                                <xsl:if test="gmd:individualName">
-                                                    <xsl:call-template name="writeCharacterStringElement">
-                                                        <xsl:with-param name="elementName" select="'cit:name'"/>
-                                                        <xsl:with-param name="nodeWithStringToWrite" select="gmd:individualName"/>
-                                                    </xsl:call-template>
-                                                </xsl:if>
-                                                <xsl:if test="gmd:positionName">
-                                                    <xsl:call-template name="writeCharacterStringElement">
-                                                        <xsl:with-param name="elementName" select="'cit:positionName'"/>
-                                                        <xsl:with-param name="nodeWithStringToWrite" select="gmd:positionName"/>
-                                                    </xsl:call-template>
-                                                </xsl:if>
-                                            </cit:CI_Individual>
-                                        </cit:individual>
-                                    </xsl:if>
-                                </cit:CI_Organisation>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <cit:CI_Individual>
-                                    <xsl:if test="gmd:individualName">
-                                        <xsl:call-template name="writeCharacterStringElement">
-                                            <xsl:with-param name="elementName" select="'cit:name'"/>
-                                            <xsl:with-param name="nodeWithStringToWrite" select="gmd:individualName"/>
-                                        </xsl:call-template>
-                                    </xsl:if>
-                                    <xsl:call-template name="writeContactInformation"/>
-                                    <xsl:if test="gmd:positionName">
-                                        <xsl:call-template name="writeCharacterStringElement">
-                                            <xsl:with-param name="elementName" select="'cit:positionName'"/>
-                                            <xsl:with-param name="nodeWithStringToWrite" select="gmd:positionName"/>
-                                        </xsl:call-template>
-                                    </xsl:if>
-                                </cit:CI_Individual>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                        <!--<xsl:apply-templates/>-->
-                    </cit:party>
-                </xsl:element>
-            </xsl:when>
-        </xsl:choose>
+       <xsl:element name="cit:CI_Responsibility">
+           <xsl:apply-templates select="./@*" mode="from19139to19115-3"/>
+            <xsl:choose>
+                <xsl:when test="./gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
+                  <xsl:choose>
+                    <xsl:when test="gmd:role/gmd:CI_RoleCode/@codeListValue = 'coInvestigator'">
+                      <xsl:call-template name="writeCodelistElement">
+                        <xsl:with-param name="elementName" select="'cit:role'"/>
+                        <xsl:with-param name="codeListName" select="'cit:CI_RoleCode'"/>
+                        <xsl:with-param name="codeListValue" select="'collaborator'"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:when test="gmd:role/gmd:CI_RoleCode/@codeListValue = 'metadataContact'">
+                      <xsl:call-template name="writeCodelistElement">
+                        <xsl:with-param name="elementName" select="'cit:role'"/>
+                        <xsl:with-param name="codeListName" select="'cit:CI_RoleCode'"/>
+                        <xsl:with-param name="codeListValue" select="'pointOfContact'"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="writeCodelistElement">
+                        <xsl:with-param name="elementName" select="'cit:role'"/>
+                        <xsl:with-param name="codeListName" select="'cit:CI_RoleCode'"/>
+                        <xsl:with-param name="codeListValue" select="gmd:role/gmd:CI_RoleCode/@codeListValue"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </xsl:when>
+                <xsl:when test="./gmd:role/@*">
+                    <cit:role>
+                        <xsl:apply-templates select="./gmd:role/@*" mode="from19139to19115-3"/>
+                    </cit:role>
+                </xsl:when>
+                <xsl:otherwise>
+                    <cit:role gco:nilReason="missing"/>
+                </xsl:otherwise>
+            </xsl:choose>
+            <cit:party>
+                <xsl:choose>
+                    <xsl:when test="gmd:organisationName">
+                        <cit:CI_Organisation>
+                            <xsl:call-template name="writeCharacterStringElement">
+                                <xsl:with-param name="elementName" select="'cit:name'"/>
+                                <xsl:with-param name="nodeWithStringToWrite" select="gmd:organisationName"/>
+                            </xsl:call-template>
+                            <!-- contactInformation comes before indivudual/position -->
+                            <xsl:call-template name="writeContactInformation"/>
+                            <xsl:if test="gmd:individualName | gmd:positionName">
+                                <cit:individual>
+                                    <cit:CI_Individual>
+                                        <xsl:if test="gmd:individualName">
+                                            <xsl:call-template name="writeCharacterStringElement">
+                                                <xsl:with-param name="elementName" select="'cit:name'"/>
+                                                <xsl:with-param name="nodeWithStringToWrite" select="gmd:individualName"/>
+                                            </xsl:call-template>
+                                        </xsl:if>
+                                        <xsl:if test="gmd:positionName">
+                                            <xsl:call-template name="writeCharacterStringElement">
+                                                <xsl:with-param name="elementName" select="'cit:positionName'"/>
+                                                <xsl:with-param name="nodeWithStringToWrite" select="gmd:positionName"/>
+                                            </xsl:call-template>
+                                        </xsl:if>
+                                    </cit:CI_Individual>
+                                </cit:individual>
+                            </xsl:if>
+                        </cit:CI_Organisation>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <cit:CI_Individual>
+                            <xsl:if test="gmd:individualName">
+                                <xsl:call-template name="writeCharacterStringElement">
+                                    <xsl:with-param name="elementName" select="'cit:name'"/>
+                                    <xsl:with-param name="nodeWithStringToWrite" select="gmd:individualName"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                            <xsl:call-template name="writeContactInformation"/>
+                            <xsl:if test="gmd:positionName">
+                                <xsl:call-template name="writeCharacterStringElement">
+                                    <xsl:with-param name="elementName" select="'cit:positionName'"/>
+                                    <xsl:with-param name="nodeWithStringToWrite" select="gmd:positionName"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                        </cit:CI_Individual>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <!--<xsl:apply-templates/>-->
+            </cit:party>
+        </xsl:element>
     </xsl:template>
     <xsl:template name="CI_ResponsiblePartyToOnlineResource">
         <!--

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/core.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/core.xsl
@@ -528,30 +528,9 @@
   gmd:identificationInformation templates
   -->
   <xsl:template match="/*/gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty" mode="from19139to19115-3">
-    <xsl:if test="not(preceding-sibling::gmd:citedResponsibleParty) and /*/gmd:dataSetURI">
-      <!-- **********************************************************************
-      The first citedResponsibleParty is special because the identifier
-      created from the gmd:dataSetURI goes before it.
-      WARNING: A record with a dataSetIdentifier and no
-      citedResponsibleParties will fail.
-      ********************************************************************** -->
-      <cit:identifier>
-        <mcc:MD_Identifier>
-          <mcc:code>
-            <gco:CharacterString>
-              <xsl:value-of select="/*/gmd:dataSetURI/gcoold:CharacterString"/>
-            </gco:CharacterString>
-          </mcc:code>
-        </mcc:MD_Identifier>
-      </cit:identifier>
-    </xsl:if>
-    <!-- Avoid putting out empty citedResponsibleParties for just onlineResources (responsible parties without names) -->
-    <xsl:if
-      test="count(gmd:CI_ResponsibleParty/gmd:individualName/gcoold:CharacterString) + count(gmd:CI_ResponsibleParty/gmd:organisationName/gcoold:CharacterString) + count(gmd:CI_ResponsibleParty/gmd:positionName/gcoold:CharacterString) != 0">
-      <cit:citedResponsibleParty>
-        <xsl:apply-templates mode="from19139to19115-3"/>
-      </cit:citedResponsibleParty>
-    </xsl:if>
+    <cit:citedResponsibleParty>
+      <xsl:apply-templates mode="from19139to19115-3"/>
+    </cit:citedResponsibleParty>
   </xsl:template>
   <xsl:template match="/*/gmd:identificationInfo/*/gmd:resourceSpecificUsage/gmd:MD_Usage/gmd:usageDateTime" mode="from19139to19115-3">
     <mri:usageDateTime>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/core.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/core.xsl
@@ -528,9 +528,13 @@
   gmd:identificationInformation templates
   -->
   <xsl:template match="/*/gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty" mode="from19139to19115-3">
-    <cit:citedResponsibleParty>
-      <xsl:apply-templates mode="from19139to19115-3"/>
-    </cit:citedResponsibleParty>
+    <!-- Avoid putting out empty citedResponsibleParties for just onlineResources (responsible parties without names) -->
+    <xsl:if
+      test="count(gmd:CI_ResponsibleParty/gmd:individualName/gcoold:CharacterString) + count(gmd:CI_ResponsibleParty/gmd:organisationName/gcoold:CharacterString) + count(gmd:CI_ResponsibleParty/gmd:positionName/gcoold:CharacterString) != 0">
+      <cit:citedResponsibleParty>
+        <xsl:apply-templates mode="from19139to19115-3"/>
+      </cit:citedResponsibleParty>
+    </xsl:if>
   </xsl:template>
   <xsl:template match="/*/gmd:identificationInfo/*/gmd:resourceSpecificUsage/gmd:MD_Usage/gmd:usageDateTime" mode="from19139to19115-3">
     <mri:usageDateTime>
@@ -588,13 +592,13 @@
         <xsl:call-template name="writeCodelistElement">
           <xsl:with-param name="elementName" select="'mri:associationType'"/>
           <xsl:with-param name="codeListName" select="'mri:DS_AssociationTypeCode'"/>
-          <xsl:with-param name="codeListValue" select="./gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode"/>
+          <xsl:with-param name="codeListValue" select="./gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode/@codeListValue"/>
           <xsl:with-param name="required" select="true()"/>
         </xsl:call-template>
         <xsl:call-template name="writeCodelistElement">
           <xsl:with-param name="elementName" select="'mri:initiativeType'"/>
           <xsl:with-param name="codeListName" select="'mri:DS_InitiativeTypeCode'"/>
-          <xsl:with-param name="codeListValue" select="./gmd:MD_AggregateInformation/gmd:initiativeType/gmd:DS_InitiativeTypeCode"/>
+          <xsl:with-param name="codeListValue" select="./gmd:MD_AggregateInformation/gmd:initiativeType/gmd:DS_InitiativeTypeCode/@codeListValue"/>
         </xsl:call-template>
       </xsl:element>
     </mri:associatedResource>
@@ -609,9 +613,11 @@
         <xsl:apply-templates select="ancestor::gmd:MD_AggregateInformation/gmd:aggregateDataSetIdentifier/gmd:MD_Identifier" mode="from19139to19115-3"/>
       </cit:identifier>
     </xsl:if>
-    <cit:citedResponsibleParty>
-      <xsl:apply-templates mode="from19139to19115-3"/>
-    </cit:citedResponsibleParty>
+    <xsl:if test="gmd:CI_ResponsibleParty[count(gmd:individualName/gcoold:CharacterString) + count(gmd:organisationName/gcoold:CharacterString) + count(gmd:positionName/gcoold:CharacterString) > 0]">
+      <cit:citedResponsibleParty>
+        <xsl:apply-templates mode="from19139to19115-3"/>
+      </cit:citedResponsibleParty>
+    </xsl:if>
   </xsl:template>
   <!--
     gmd:referenceSystemInformation templates

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/mcpdataparameters_aodn.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/mcpdataparameters_aodn.xsl
@@ -57,7 +57,7 @@
               <mrc:MD_CoverageContentTypeCode codeList='http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CoverageContentTypeCode' codeListValue='physicalMeasurement'/>
             </mrc:contentType>
             <xsl:for-each-group select="mcp:DP_DataParameters/mcp:dataParameter/mcp:DP_DataParameter"
-                                group-by="mcp:parameterName/*[*/mcp:DP_TypeCode/@codeListValue='longName']/mcp:term/*/text()">
+                                group-by="(mcp:parameterName/*[mcp:type/*/@codeListValue='longName']|mcp:parameterName/*[mcp:type/*/@codeListValue='shortName'])[1]/mcp:term/*/text()">
               <xsl:variable name="dataParameter" select="current-group()[1]"/>
               <xsl:variable name="longName" select="$dataParameter/mcp:parameterName[*/*/mcp:DP_TypeCode/@codeListValue='longName']"/>
 
@@ -79,77 +79,42 @@
                         </mrc:description>
                       </xsl:when>
                     </xsl:choose>
-                    <mrc:name>
-                      <mcc:MD_Identifier>
-                        <mcc:code>
-                          <xsl:choose>
-                            <xsl:when test="$longName/*/mcp:vocabularyTermURL/gmd:URL">
-                              <gcx:Anchor xlink:href="{$longName/*/mcp:vocabularyTermURL/gmd:URL}">
-                                <xsl:value-of select="$longName/*/mcp:term/*/text()"/>
-                              </gcx:Anchor>
-                            </xsl:when>
-                            <xsl:otherwise>
-                              <gco:CharacterString>
-                                <xsl:value-of select="$longName/*/mcp:term/*/text()"/>
-                              </gco:CharacterString>
-                            </xsl:otherwise>
-                          </xsl:choose>
-                        </mcc:code>
-                        <xsl:choose>
-                          <xsl:when test="$longName//mcp:vocabularyListURL/gmd:URL">
-                            <mcc:codeSpace>
-                              <gco:CharacterString>
-                                <xsl:value-of select="$longName//mcp:vocabularyListURL/gmd:URL"/>
-                              </gco:CharacterString>
-                            </mcc:codeSpace>
-                          </xsl:when>
-                        </xsl:choose>
-                        <xsl:if test="$longName/*/mcp:termDefinition">
-                          <mcc:description>
-                            <gco:CharacterString>
-                              <xsl:value-of select="$longName/*/mcp:termDefinition"/>
-                            </gco:CharacterString>
-                          </mcc:description>
-                        </xsl:if>
-                      </mcc:MD_Identifier>
-                    </mrc:name>
-                    <xsl:if test="$dataParameter/mcp:parameterName[*/*/mcp:DP_TypeCode/@codeListValue='shortName']">
-                      <xsl:variable name="shortName" select="$dataParameter/mcp:parameterName[mcp:DP_Term/*/mcp:DP_TypeCode/@codeListValue='shortName']"/>
+                    <xsl:for-each select="$dataParameter/mcp:parameterName/mcp:DP_Term">
                       <mrc:name>
                         <mcc:MD_Identifier>
                           <mcc:code>
                             <xsl:choose>
-                              <xsl:when test="$shortName/*/mcp:vocabularyTermURL/gmd:URL">
-                                <gcx:Anchor xlink:href="{$shortName/*/mcp:vocabularyTermURL/gmd:URL}">
-                                  <xsl:value-of select="$shortName/*/mcp:term/*/text()"/>
+                              <xsl:when test="mcp:vocabularyTermURL/gmd:URL">
+                                <gcx:Anchor xlink:href="{mcp:vocabularyTermURL/gmd:URL}">
+                                  <xsl:value-of select="mcp:term/*/text()"/>
                                 </gcx:Anchor>
                               </xsl:when>
                               <xsl:otherwise>
                                 <gco:CharacterString>
-                                  <xsl:value-of select="$shortName/*/mcp:term/*/text()"/>
+                                  <xsl:value-of select="mcp:term/*/text()"/>
                                 </gco:CharacterString>
                               </xsl:otherwise>
                             </xsl:choose>
                           </mcc:code>
                           <xsl:choose>
-                            <xsl:when test="$shortName//mcp:vocabularyListURL/gmd:URL">
+                            <xsl:when test=".//mcp:vocabularyListURL/gmd:URL">
                               <mcc:codeSpace>
                                 <gco:CharacterString>
-                                  <xsl:value-of select="$shortName//mcp:vocabularyListURL/gmd:URL"/>
+                                  <xsl:value-of select=".//mcp:vocabularyListURL/gmd:URL"/>
                                 </gco:CharacterString>
                               </mcc:codeSpace>
                             </xsl:when>
                           </xsl:choose>
-                          <xsl:if test="$shortName/*/mcp:termDefinition">
+                          <xsl:if test="mcp:termDefinition">
                             <mcc:description>
                               <gco:CharacterString>
-                                <xsl:value-of select="$shortName/*/mcp:termDefinition"/>
+                                <xsl:value-of select="mcp:termDefinition"/>
                               </gco:CharacterString>
                             </mcc:description>
                           </xsl:if>
                         </mcc:MD_Identifier>
                       </mrc:name>
-                    </xsl:if>
+                    </xsl:for-each>
                     <xsl:if test="string(number($dataParameter/mcp:parameterMaximumValue/*)) != 'NaN'">
                       <mrc:maxValue>
                         <gco:Real><xsl:value-of select="$dataParameter/mcp:parameterMaximumValue/*"/></gco:Real>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/mcpdataparameters_descriptiveKeywords_aodn.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/mcpdataparameters_descriptiveKeywords_aodn.xsl
@@ -31,6 +31,12 @@
         <xsl:with-param name="typeCode" select="'theme'"/>
         <xsl:with-param name="defaultThesaurus" select="'parameter'"/>
       </xsl:apply-templates>
+      <!-- Add keywords for parameters with only a short name - as per IMAS usage -->
+      <xsl:apply-templates mode="map-term" select=".//mcp:dataParameter[not(.//mcp:parameterName[*/*/mcp:DP_TypeCode/@codeListValue='longName'])]
+                                                    //mcp:parameterName[*/mcp:type/*/@codeListValue='shortName']">
+        <xsl:with-param name="typeCode" select="'theme'"/>
+        <xsl:with-param name="defaultThesaurus" select="'parameter'"/>
+      </xsl:apply-templates>
       <xsl:apply-templates mode="map-term" select=".//mcp:parameterDeterminationInstrument[*/*/mcp:DP_TypeCode/@codeListValue='longName']">
         <xsl:with-param name="typeCode" select="'instrument'"/>
         <xsl:with-param name="defaultThesaurus" select="'instrument'"/>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/aggregationInfo/expected/C1412710076-AU_AADC.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/aggregationInfo/expected/C1412710076-AU_AADC.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdb:MD_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
+                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+                 xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
+                 xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
+                 xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                 xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+                 xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
+                 xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                 xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/1.0"
+                 xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/1.0"
+                 xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
+                 xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+                 xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
+                 xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                 xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                 xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                 xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
+                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
+                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
+                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xsi:schemaLocation="http://standards.iso.org/iso/19115/-3/cat/1.0 http://standards.iso.org/iso/19115/-3/cat/1.0/cat.xsd http://standards.iso.org/iso/19115/-3/cit/2.0 http://standards.iso.org/iso/19115/-3/cit/2.0/cit.xsd http://standards.iso.org/iso/19115/-3/gcx/1.0 http://standards.iso.org/iso/19115/-3/gcx/1.0/gcx.xsd http://standards.iso.org/iso/19115/-3/gex/1.0 http://standards.iso.org/iso/19115/-3/gex/1.0/gex.xsd http://standards.iso.org/iso/19115/-3/lan/1.0 http://standards.iso.org/iso/19115/-3/lan/1.0/lan.xsd http://standards.iso.org/iso/19115/-3/srv/2.0 http://standards.iso.org/iso/19115/-3/srv/2.0/srv.xsd http://standards.iso.org/iso/19115/-3/mas/1.0 http://standards.iso.org/iso/19115/-3/mas/1.0/mas.xsd http://standards.iso.org/iso/19115/-3/mcc/1.0 http://standards.iso.org/iso/19115/-3/mcc/1.0/mcc.xsd http://standards.iso.org/iso/19115/-3/mco/1.0 http://standards.iso.org/iso/19115/-3/mco/1.0/mco.xsd http://standards.iso.org/iso/19115/-3/mda/2.0 http://standards.iso.org/iso/19115/-3/mda/2.0/mda.xsd http://standards.iso.org/iso/19115/-3/mdb/2.0 http://standards.iso.org/iso/19115/-3/mdb/2.0/mdb.xsd http://standards.iso.org/iso/19115/-3/mds/2.0 http://standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd http://standards.iso.org/iso/19115/-3/mdt/2.0 http://standards.iso.org/iso/19115/-3/mdt/2.0/mdt.xsd http://standards.iso.org/iso/19115/-3/mex/1.0 http://standards.iso.org/iso/19115/-3/mex/1.0/mex.xsd http://standards.iso.org/iso/19115/-3/mmi/1.0 http://standards.iso.org/iso/19115/-3/mmi/1.0/mmi.xsd http://standards.iso.org/iso/19115/-3/mpc/1.0 http://standards.iso.org/iso/19115/-3/mpc/1.0/mpc.xsd http://standards.iso.org/iso/19115/-3/mrc/2.0 http://standards.iso.org/iso/19115/-3/mrc/2.0/mrc.xsd http://standards.iso.org/iso/19115/-3/mrd/1.0 http://standards.iso.org/iso/19115/-3/mrd/1.0/mrd.xsd http://standards.iso.org/iso/19115/-3/mri/1.0 http://standards.iso.org/iso/19115/-3/mri/1.0/mri.xsd http://standards.iso.org/iso/19115/-3/mrl/2.0 http://standards.iso.org/iso/19115/-3/mrl/2.0/mrl.xsd http://standards.iso.org/iso/19115/-3/mrs/1.0 http://standards.iso.org/iso/19115/-3/mrs/1.0/mrs.xsd http://standards.iso.org/iso/19115/-3/msr/2.0 http://standards.iso.org/iso/19115/-3/msr/2.0/msr.xsd http://standards.iso.org/iso/19157/-2/mdq/1.0 http://standards.iso.org/iso/19157/-2/mdq/1.0/mdq.xsd http://standards.iso.org/iso/19115/-3/mac/2.0 http://standards.iso.org/iso/19115/-3/mac/2.0/mac.xsd http://standards.iso.org/iso/19115/-3/gco/1.0 http://standards.iso.org/iso/19115/-3/gco/1.0/gco.xsd http://standards.iso.org/iso/19115/-3/gmw/1.0 http://standards.iso.org/iso/19115/-3/gmw/1.0/gmw.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://www.w3.org/1999/xlink http://www.w3.org/1999/xlink.xsd">
+   <mdb:metadataIdentifier>
+      <mcc:MD_Identifier>
+         <mcc:code>
+            <gco:CharacterString>C1412710076-AU_AADC</gco:CharacterString>
+         </mcc:code>
+      </mcc:MD_Identifier>
+   </mdb:metadataIdentifier>
+   <mdb:contact gco:nilReason="missing"/>
+   <mdb:dateInfo gco:nilReason="missing"/>
+   <mdb:metadataStandard>
+      <cit:CI_Citation>
+         <cit:title>
+            <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
+         </cit:title>
+      </cit:CI_Citation>
+   </mdb:metadataStandard>
+   <mdb:identificationInfo>
+      <mri:MD_DataIdentification>
+         <mri:citation gco:nilReason="missing"/>
+         <mri:abstract gco:nilReason="missing"/>
+         <mri:associatedResource>
+            <mri:MD_AssociatedResource>
+               <mri:name>
+                  <cit:CI_Citation>
+                     <cit:title>
+                        <gco:CharacterString>Population trend in right whales off southern Australia 1993-2015.</gco:CharacterString>
+                     </cit:title>
+                     <cit:date>
+                        <cit:CI_Date>
+                           <cit:date>
+                              <gco:DateTime>2016-01-01T00:00:00</gco:DateTime>
+                           </cit:date>
+                           <cit:dateType>
+                              <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                                                   codeListValue="publication"/>
+                           </cit:dateType>
+                        </cit:CI_Date>
+                     </cit:date>
+                     <cit:citedResponsibleParty>
+                        <cit:CI_Responsibility>
+                           <cit:role>
+                              <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode"
+                                               codeListValue="author"/>
+                           </cit:role>
+                           <cit:party>
+                              <cit:CI_Organisation>
+                                 <cit:name>
+                                    <gco:CharacterString>Bannister, JL, Hammond, PS and Double, MC</gco:CharacterString>
+                                 </cit:name>
+                              </cit:CI_Organisation>
+                           </cit:party>
+                        </cit:CI_Responsibility>
+                     </cit:citedResponsibleParty>
+                     <cit:series>
+                        <cit:CI_Series>
+                           <cit:name>
+                              <gco:CharacterString>IWC Scientific Committee</gco:CharacterString>
+                           </cit:name>
+                        </cit:CI_Series>
+                     </cit:series>
+                     <cit:otherCitationDetails>
+                        <gco:CharacterString>Paper submitted for consideration by the IWC Scientific Committee.</gco:CharacterString>
+                     </cit:otherCitationDetails>
+                  </cit:CI_Citation>
+               </mri:name>
+               <mri:associationType>
+                  <mri:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode"
+                                              codeListValue="crossReference"/>
+               </mri:associationType>
+            </mri:MD_AssociatedResource>
+         </mri:associatedResource>
+         <mri:associatedResource>
+            <mri:MD_AssociatedResource>
+               <mri:name>
+                  <cit:CI_Citation>
+                     <cit:title gco:nilReason="missing"/>
+                     <cit:date gco:nilReason="missing"/>
+                     <cit:onlineResource>
+                        <cit:CI_OnlineResource>
+                           <cit:linkage>
+                              <gco:CharacterString>https://data.aad.gov.au/aadc/metadata/citation.cfm?entry_id=NESP_2016_SRW</gco:CharacterString>
+                           </cit:linkage>
+                           <cit:name>
+                              <gco:CharacterString>Description: Citation reference for this metadata record and dataset. URLContentType: PublicationURL Type: VIEW RELATED INFORMATION</gco:CharacterString>
+                           </cit:name>
+                        </cit:CI_OnlineResource>
+                     </cit:onlineResource>
+                  </cit:CI_Citation>
+               </mri:name>
+               <mri:associationType gco:nilReason="missing"/>
+            </mri:MD_AssociatedResource>
+         </mri:associatedResource>
+         <mri:defaultLocale>
+            <lan:PT_Locale>
+               <lan:language>
+                  <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+               </lan:language>
+               <lan:characterEncoding gco:nilReason="unknown"/>
+            </lan:PT_Locale>
+         </mri:defaultLocale>
+      </mri:MD_DataIdentification>
+   </mdb:identificationInfo>
+</mdb:MD_Metadata>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/aggregationInfo/export/C1412710076-AU_AADC/info.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/aggregationInfo/export/C1412710076-AU_AADC/info.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<info version="1.1">
+  <general>
+    <createDate>2020-02-17T20:01:01</createDate>
+    <changeDate>2020-02-17T20:10:44</changeDate>
+    <schema>iso19139</schema>
+    <isTemplate>false</isTemplate>
+    <localId>1073</localId>
+    <format>full</format>
+    <rating>0</rating>
+    <popularity>253</popularity>
+    <uuid>C1412710076-AU_AADC</uuid>
+    <siteId>8d77e503-5ddb-4079-8e5e-02699e9219e3</siteId>
+    <siteName>University of Tasmania, Australia</siteName>
+  </general>
+  <categories />
+  <privileges>
+    <group name="all">
+      <operation name="view" />
+      <operation name="download" />
+      <operation name="dynamic" />
+      <operation name="featured" />
+    </group>
+  </privileges>
+  <public />
+  <private />
+</info>
+

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/aggregationInfo/export/C1412710076-AU_AADC/metadata/metadata.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/aggregationInfo/export/C1412710076-AU_AADC/metadata/metadata.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:eos="http://earthdata.nasa.gov/schema/eos" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:swe="http://schemas.opengis.net/sweCommon/2.0/" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:geonet="http://www.fao.org/geonetwork">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>C1412710076-AU_AADC</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:contact gco:nilReason="missing">
+  </gmd:contact>
+  <gmd:dateStamp gco:nilReason="missing">
+  </gmd:dateStamp>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation gco:nilReason="missing"/>
+      <gmd:abstract gco:nilReason="missing"/>
+      <gmd:aggregationInfo>
+        <gmd:MD_AggregateInformation>
+          <gmd:aggregateDataSetName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>Population trend in right whales off southern Australia 1993-2015.</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-01-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>Bannister, JL, Hammond, PS and Double, MC</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode" codeListValue="author" />
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode" codeListValue="publisher" />
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+              <gmd:series>
+                <gmd:CI_Series>
+                  <gmd:name>
+                    <gco:CharacterString>IWC Scientific Committee</gco:CharacterString>
+                  </gmd:name>
+                </gmd:CI_Series>
+              </gmd:series>
+              <gmd:otherCitationDetails>
+                <gco:CharacterString>Paper submitted for consideration by the IWC Scientific Committee.</gco:CharacterString>
+              </gmd:otherCitationDetails>
+            </gmd:CI_Citation>
+          </gmd:aggregateDataSetName>
+          <gmd:associationType>
+            <gmd:DS_AssociationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#DS_AssociationTypeCode" codeListValue="crossReference" />
+          </gmd:associationType>
+        </gmd:MD_AggregateInformation>
+      </gmd:aggregationInfo>
+      <gmd:aggregationInfo>
+        <gmd:MD_AggregateInformation>
+          <gmd:aggregateDataSetName>
+            <gmd:CI_Citation>
+              <gmd:title gco:nilReason="missing" />
+              <gmd:date gco:nilReason="missing" />
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                          <gmd:linkage>
+                            <gmd:URL>https://data.aad.gov.au/aadc/metadata/citation.cfm?entry_id=NESP_2016_SRW</gmd:URL>
+                          </gmd:linkage>
+                          <gmd:description>
+                            <gco:CharacterString>Description: Citation reference for this metadata record and dataset. URLContentType: PublicationURL Type: VIEW RELATED INFORMATION</gco:CharacterString>
+                          </gmd:description>
+                        </gmd:CI_OnlineResource>
+                      </gmd:onlineResource>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode" codeListValue="" />
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:aggregateDataSetName>
+          <gmd:associationType gco:nilReason="missing" />
+        </gmd:MD_AggregateInformation>
+      </gmd:aggregationInfo>
+      <gmd:language>
+        <gco:CharacterString xmlns:srv="http://www.isotc211.org/2005/srv">eng</gco:CharacterString>
+      </gmd:language>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/expected/357591e6-e0f8-4d30-a7d1-c875c004da4c.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/expected/357591e6-e0f8-4d30-a7d1-c875c004da4c.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdb:MD_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
+                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+                 xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
+                 xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
+                 xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                 xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+                 xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
+                 xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                 xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/1.0"
+                 xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/1.0"
+                 xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
+                 xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+                 xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
+                 xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                 xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                 xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                 xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
+                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
+                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
+                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xsi:schemaLocation="http://standards.iso.org/iso/19115/-3/cat/1.0 http://standards.iso.org/iso/19115/-3/cat/1.0/cat.xsd http://standards.iso.org/iso/19115/-3/cit/2.0 http://standards.iso.org/iso/19115/-3/cit/2.0/cit.xsd http://standards.iso.org/iso/19115/-3/gcx/1.0 http://standards.iso.org/iso/19115/-3/gcx/1.0/gcx.xsd http://standards.iso.org/iso/19115/-3/gex/1.0 http://standards.iso.org/iso/19115/-3/gex/1.0/gex.xsd http://standards.iso.org/iso/19115/-3/lan/1.0 http://standards.iso.org/iso/19115/-3/lan/1.0/lan.xsd http://standards.iso.org/iso/19115/-3/srv/2.0 http://standards.iso.org/iso/19115/-3/srv/2.0/srv.xsd http://standards.iso.org/iso/19115/-3/mas/1.0 http://standards.iso.org/iso/19115/-3/mas/1.0/mas.xsd http://standards.iso.org/iso/19115/-3/mcc/1.0 http://standards.iso.org/iso/19115/-3/mcc/1.0/mcc.xsd http://standards.iso.org/iso/19115/-3/mco/1.0 http://standards.iso.org/iso/19115/-3/mco/1.0/mco.xsd http://standards.iso.org/iso/19115/-3/mda/2.0 http://standards.iso.org/iso/19115/-3/mda/2.0/mda.xsd http://standards.iso.org/iso/19115/-3/mdb/2.0 http://standards.iso.org/iso/19115/-3/mdb/2.0/mdb.xsd http://standards.iso.org/iso/19115/-3/mds/2.0 http://standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd http://standards.iso.org/iso/19115/-3/mdt/2.0 http://standards.iso.org/iso/19115/-3/mdt/2.0/mdt.xsd http://standards.iso.org/iso/19115/-3/mex/1.0 http://standards.iso.org/iso/19115/-3/mex/1.0/mex.xsd http://standards.iso.org/iso/19115/-3/mmi/1.0 http://standards.iso.org/iso/19115/-3/mmi/1.0/mmi.xsd http://standards.iso.org/iso/19115/-3/mpc/1.0 http://standards.iso.org/iso/19115/-3/mpc/1.0/mpc.xsd http://standards.iso.org/iso/19115/-3/mrc/2.0 http://standards.iso.org/iso/19115/-3/mrc/2.0/mrc.xsd http://standards.iso.org/iso/19115/-3/mrd/1.0 http://standards.iso.org/iso/19115/-3/mrd/1.0/mrd.xsd http://standards.iso.org/iso/19115/-3/mri/1.0 http://standards.iso.org/iso/19115/-3/mri/1.0/mri.xsd http://standards.iso.org/iso/19115/-3/mrl/2.0 http://standards.iso.org/iso/19115/-3/mrl/2.0/mrl.xsd http://standards.iso.org/iso/19115/-3/mrs/1.0 http://standards.iso.org/iso/19115/-3/mrs/1.0/mrs.xsd http://standards.iso.org/iso/19115/-3/msr/2.0 http://standards.iso.org/iso/19115/-3/msr/2.0/msr.xsd http://standards.iso.org/iso/19157/-2/mdq/1.0 http://standards.iso.org/iso/19157/-2/mdq/1.0/mdq.xsd http://standards.iso.org/iso/19115/-3/mac/2.0 http://standards.iso.org/iso/19115/-3/mac/2.0/mac.xsd http://standards.iso.org/iso/19115/-3/gco/1.0 http://standards.iso.org/iso/19115/-3/gco/1.0/gco.xsd http://standards.iso.org/iso/19115/-3/gmw/1.0 http://standards.iso.org/iso/19115/-3/gmw/1.0/gmw.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://www.w3.org/1999/xlink http://www.w3.org/1999/xlink.xsd">
+   <mdb:metadataIdentifier>
+      <mcc:MD_Identifier>
+         <mcc:code>
+            <gco:CharacterString>357591e6-e0f8-4d30-a7d1-c875c004da4c</gco:CharacterString>
+         </mcc:code>
+      </mcc:MD_Identifier>
+   </mdb:metadataIdentifier>
+   <mdb:contact gco:nilReason="missing"/>
+   <mdb:dateInfo gco:nilReason="missing"/>
+   <mdb:metadataStandard>
+      <cit:CI_Citation>
+         <cit:title>
+            <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
+         </cit:title>
+      </cit:CI_Citation>
+   </mdb:metadataStandard>
+   <mdb:identificationInfo>
+      <mri:MD_DataIdentification>
+         <mri:citation gco:nilReason="missing"/>
+         <mri:abstract gco:nilReason="missing"/>
+         <mri:descriptiveKeywords>
+            <mri:MD_Keywords>
+               <mri:keyword>
+                  <gco:CharacterString>pH</gco:CharacterString>
+               </mri:keyword>
+               <mri:type>
+                  <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="theme"/>
+               </mri:type>
+            </mri:MD_Keywords>
+         </mri:descriptiveKeywords>
+         <mri:defaultLocale>
+            <lan:PT_Locale>
+               <lan:language>
+                  <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+               </lan:language>
+               <lan:characterEncoding gco:nilReason="unknown"/>
+            </lan:PT_Locale>
+         </mri:defaultLocale>
+      </mri:MD_DataIdentification>
+   </mdb:identificationInfo>
+   <mdb:contentInfo>
+      <mrc:MD_CoverageDescription>
+         <mrc:attributeDescription gco:nilReason="inapplicable"/>
+         <mrc:attributeGroup>
+            <mrc:MD_AttributeGroup>
+               <mrc:contentType>
+                  <mrc:MD_CoverageContentTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CoverageContentTypeCode"
+                                                  codeListValue="physicalMeasurement"/>
+               </mrc:contentType>
+               <mrc:attribute>
+                  <mrc:MD_SampleDimension>
+                     <mrc:description gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </mrc:description>
+                     <mrc:name>
+                        <mcc:MD_Identifier>
+                           <mcc:code>
+                              <gco:CharacterString>pH</gco:CharacterString>
+                           </mcc:code>
+                        </mcc:MD_Identifier>
+                     </mrc:name>
+                     <mrc:units>
+                        <gml:BaseUnit gml:id="d20e16">
+                           <gml:identifier codeSpace="unknown"/>
+                           <gml:name/>
+                           <gml:unitsSystem/>
+                        </gml:BaseUnit>
+                     </mrc:units>
+                  </mrc:MD_SampleDimension>
+               </mrc:attribute>
+            </mrc:MD_AttributeGroup>
+         </mrc:attributeGroup>
+      </mrc:MD_CoverageDescription>
+   </mdb:contentInfo>
+</mdb:MD_Metadata>

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/export/357591e6-e0f8-4d30-a7d1-c875c004da4c/info.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/export/357591e6-e0f8-4d30-a7d1-c875c004da4c/info.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<info version="1.1">
+  <general>
+    <createDate>2011-11-21T14:06:02</createDate>
+    <changeDate>2018-12-17T11:47:07</changeDate>
+    <schema>iso19139.mcp-2.0</schema>
+    <isTemplate>false</isTemplate>
+    <localId>242</localId>
+    <format>full</format>
+    <rating>0</rating>
+    <popularity>2643</popularity>
+    <uuid>357591e6-e0f8-4d30-a7d1-c875c004da4c</uuid>
+    <siteId>b9264f25-6e6f-4032-87cf-22be154e6411</siteId>
+    <siteName>University of Tasmania, Australia</siteName>
+  </general>
+  <categories />
+  <privileges>
+    <group name="all">
+      <operation name="view" />
+      <operation name="download" />
+    </group>
+  </privileges>
+  <public>
+    <file name="csq_map150_229_226_17_84491115368I64P_s.png" changeDate="2011-11-21T14:09:01" />
+    <file name="csq_map150_229_226_17_84491115368I64P.png" changeDate="2011-11-21T14:09:02" />
+  </public>
+  <private>
+    <file name="Developing_monitoring_program_MontaguRiverdataset.xlsx" changeDate="2011-11-24T16:22:52" />
+    <file name="CCNRM_report_1.pdf" changeDate="2011-11-21T14:06:02" />
+  </private>
+</info>
+

--- a/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/export/357591e6-e0f8-4d30-a7d1-c875c004da4c/metadata/metadata.xml
+++ b/geonetwork/transform-mcp-iso19115-3/src/test/resources/dataParameters/export/357591e6-e0f8-4d30-a7d1-c875c004da4c/metadata/metadata.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mcp:MD_Metadata xmlns:mcp="http://schemas.aodn.org.au/mcp-2.0" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dwc="http://rs.tdwg.org/dwc/terms/" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:geonet="http://www.fao.org/geonetwork" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://schemas.aodn.org.au/mcp-2.0 http://schemas.aodn.org.au/mcp-2.0/schema.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd http://rs.tdwg.org/dwc/terms/ http://schemas.aodn.org.au/mcp-2.0/mcpDwcTerms.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>357591e6-e0f8-4d30-a7d1-c875c004da4c</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:contact gco:nilReason="missing">
+  </gmd:contact>
+  <gmd:dateStamp gco:nilReason="missing">
+  </gmd:dateStamp>
+  <gmd:identificationInfo>
+    <mcp:MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation gco:nilReason="missing"/>
+      <gmd:abstract gco:nilReason="missing"/>
+      <gmd:language>
+        <gco:CharacterString xmlns:srv="http://www.isotc211.org/2005/srv">eng</gco:CharacterString>
+      </gmd:language>
+      <mcp:dataParameters>
+        <mcp:DP_DataParameters>
+          <mcp:dataParameter>
+            <mcp:DP_DataParameter>
+              <mcp:parameterName>
+                <mcp:DP_Term>
+                  <mcp:term>
+                    <gco:CharacterString>pH</gco:CharacterString>
+                  </mcp:term>
+                  <mcp:type>
+                    <mcp:DP_TypeCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#DP_TypeCode" codeListValue="shortName">shortName</mcp:DP_TypeCode>
+                  </mcp:type>
+                  <mcp:usedInDataset>
+                    <gco:Boolean>false</gco:Boolean>
+                  </mcp:usedInDataset>
+                </mcp:DP_Term>
+              </mcp:parameterName>
+              <mcp:parameterUnits>
+                <mcp:DP_Term>
+                  <mcp:term gco:nilReason="missing">
+                    <gco:CharacterString />
+                  </mcp:term>
+                  <mcp:type>
+                    <mcp:DP_TypeCode codeList="http://schemas.aodn.org.au/mcp-2.0/schema/resources/Codelist/gmxCodelists.xml#DP_TypeCode" codeListValue="" />
+                  </mcp:type>
+                  <mcp:usedInDataset>
+                    <gco:Boolean>false</gco:Boolean>
+                  </mcp:usedInDataset>
+                </mcp:DP_Term>
+              </mcp:parameterUnits>
+              <mcp:parameterMinimumValue gco:nilReason="missing">
+                <gco:CharacterString />
+              </mcp:parameterMinimumValue>
+              <mcp:parameterMaximumValue gco:nilReason="missing">
+                <gco:CharacterString />
+              </mcp:parameterMaximumValue>
+              <mcp:parameterDescription gco:nilReason="missing">
+                <gco:CharacterString />
+              </mcp:parameterDescription>
+            </mcp:DP_DataParameter>
+          </mcp:dataParameter>
+        </mcp:DP_DataParameters>
+      </mcp:dataParameters>
+    </mcp:MD_DataIdentification>
+  </gmd:identificationInfo>
+</mcp:MD_Metadata>


### PR DESCRIPTION
1. Treat short parameter names like long parameter names if there are no long parameter names for the parameter i.e Ensure sampling dimension is added for them and also add to keywords.
1. Add datasetUri as an identifier to the resource citation section even if there isn't a citedResponsibileParty in the resource citation
1. Fix issues moving onlineResource elements from citedResponsibleParty elements to their containg CI_Citation element (there was one IMAS record this was useful for).
1. Fix issues copying aggregationInfo codeList