### PR TITLE
make sure string-length is getting a string

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -79,7 +79,7 @@
             </xsl:choose>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="string-length($codeListValue) > 0">
+            <xsl:when test="string-length($codeListValue[0]) > 0">
                 <xsl:element name="{$elementName}">
                     <xsl:element name="{$codeListName}">
                         <xsl:attribute name="codeList">


### PR DESCRIPTION
the string-length was receiving a sequence rather than a single string for records where multiple codelistvalues were being matched