### PR TITLE
Handle code list value sequences in mcp to 19115 conversion

### DIFF
--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/DQ.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/mapping/DQ.xsl
@@ -153,6 +153,7 @@
                             select="$dataQualityScopeObject//gmd:MD_ScopeCode/@codeListValue|
                                     $dataQualityScopeObject//gmx:MX_ScopeCode/@codeListValue"/>
             <xsl:with-param name="required" select="true()"/>
+            <xsl:with-param name="codeListLocation">https://standards.iso.org/iso/19115/-3/mcc/1.0/codelists.xml</xsl:with-param>
           </xsl:call-template>
         </xsl:when>
           <xsl:otherwise>

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -63,8 +63,50 @@
         <xsl:param name="codeListName"/>
         <xsl:param name="codeListValue"/>
         <xsl:param name="required" select="false()"/>
-        <!-- The correct codeList Location goes here -->
-        <xsl:variable name="codeListLocation" select="'codeListLocation'"/>
+        <xsl:param name="codeListLocation" select="'codeListLocation'"/>
+        <xsl:choose>
+            <xsl:when test="$codeListValue instance of xs:string">
+                <xsl:call-template name="writeCodelistElementString">
+                    <xsl:with-param name="elementName" select="$elementName"/>
+                    <xsl:with-param name="codeListName" select="$codeListName"/>
+                    <xsl:with-param name="codeListValue" select="$codeListValue"/>
+                    <xsl:with-param name="required" select="$required"/>                    
+                    <xsl:with-param name="codeListLocation" select="$codeListLocation"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="writeCodelistElementSequence">
+                    <xsl:with-param name="elementName" select="$elementName"/>
+                    <xsl:with-param name="codeListName" select="$codeListName"/>
+                    <xsl:with-param name="codeListValue" select="$codeListValue"/>
+                    <xsl:with-param name="required" select="$required"/>                    
+                    <xsl:with-param name="codeListLocation" select="$codeListLocation"/>                    
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template name="writeCodelistElementSequence">
+        <xsl:param name="elementName"/>
+        <xsl:param name="codeListName"/>
+        <xsl:param name="codeListValue"/>
+        <xsl:param name="required"/>
+        <xsl:param name="codeListLocation"/>  
+        <xsl:for-each select="$codeListValue">
+            <xsl:call-template name="writeCodelistElementString">
+                <xsl:with-param name="elementName" select="$elementName"/>
+                <xsl:with-param name="codeListName" select="$codeListName"/>
+                <xsl:with-param name="codeListValue" select="."/>
+                <xsl:with-param name="required" select="$required"/>                    
+                <xsl:with-param name="codeListLocation" select="$codeListLocation"/>
+            </xsl:call-template>            
+        </xsl:for-each>
+    </xsl:template>
+    <xsl:template name="writeCodelistElementString">
+        <xsl:param name="elementName"/>
+        <xsl:param name="codeListName"/>
+        <xsl:param name="codeListValue"/>
+        <xsl:param name="required"/>
+        <xsl:param name="codeListLocation"/>
         <xsl:variable name="codeListValueNew">
             <xsl:choose>
                 <xsl:when test="$codeListValue='derived'">
@@ -79,7 +121,7 @@
             </xsl:choose>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="string-length($codeListValue[0]) > 0">
+            <xsl:when test="string-length($codeListValue) > 0">
                 <xsl:element name="{$elementName}">
                     <xsl:element name="{$codeListName}">
                         <xsl:attribute name="codeList">

--- a/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/geonetwork/transform-mcp-iso19115-3/schema/iso19115-3/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -91,15 +91,28 @@
         <xsl:param name="codeListValue"/>
         <xsl:param name="required"/>
         <xsl:param name="codeListLocation"/>  
-        <xsl:for-each select="$codeListValue">
-            <xsl:call-template name="writeCodelistElementString">
-                <xsl:with-param name="elementName" select="$elementName"/>
-                <xsl:with-param name="codeListName" select="$codeListName"/>
-                <xsl:with-param name="codeListValue" select="."/>
-                <xsl:with-param name="required" select="$required"/>                    
-                <xsl:with-param name="codeListLocation" select="$codeListLocation"/>
-            </xsl:call-template>            
-        </xsl:for-each>
+        <xsl:choose>
+            <xsl:when test="count($codeListValue) > 0">
+                <xsl:for-each select="$codeListValue">
+                    <xsl:call-template name="writeCodelistElementString">
+                        <xsl:with-param name="elementName" select="$elementName"/>
+                        <xsl:with-param name="codeListName" select="$codeListName"/>
+                        <xsl:with-param name="codeListValue" select="."/>
+                        <xsl:with-param name="required" select="$required"/>                    
+                        <xsl:with-param name="codeListLocation" select="$codeListLocation"/>
+                    </xsl:call-template>            
+                </xsl:for-each>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="writeCodelistElementString">
+                    <xsl:with-param name="elementName" select="$elementName"/>
+                    <xsl:with-param name="codeListName" select="$codeListName"/>
+                    <xsl:with-param name="codeListValue" select="$codeListValue"/>
+                    <xsl:with-param name="required" select="$required"/>                    
+                    <xsl:with-param name="codeListLocation" select="$codeListLocation"/>
+                </xsl:call-template>                   
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template name="writeCodelistElementString">
         <xsl:param name="elementName"/>


### PR DESCRIPTION
The initial fix for the multiple code list value issue was naive and resulting in missing data.  This one checks if it is a sequence (not a string) and explicitly creates a node for each code list value found (when it is a sequence); or creates a nilReason node if it is an empty sequence; or creates a single node if the code list value is a string.

I have also added a url for MD_ScopeCode code list location. Other code list locations are not present, but this is a separate issue (if at all) that could be addressed some other time if needed.